### PR TITLE
fix: remove armv6/7 as openjdk12 is not available on alpine 3.18

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           context: containers/opcua-device-gateway
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |


### PR DESCRIPTION
Currently openjdk12 is not available on the alpine under the cpu architectures:
* linux/armv6
* linux/armv7