### PR TITLE
feat: download opcua-device-gateway jar from official url

### DIFF
--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.18
 
 ARG BUILDTIME
 ARG REVISION
-ARG VERSION=1018.0.281
+ARG VERSION=1018.0.308
 
 LABEL org.opencontainers.image.title="thin-edge.io"
 LABEL org.opencontainers.image.created=$BUILDTIME
@@ -31,9 +31,7 @@ RUN wget -O - thin-edge.io/install.sh | sh -s
 WORKDIR /app
 
 # Download gateway from https://resources.cumulocity.com/examples/opc-ua/
-#RUN wget -O opcua-device-gateway.jar https://resources.cumulocity.com/examples/opc-ua/opcua-device-gateway-1017.0.289.jar
-# TODO: Confirm which version should be used because the avoe does not support thin-edge.io, and the jar shouldn't be hosted in the git repo
-COPY opcua-device-gateway-${VERSION}.jar opcua-device-gateway.jar
+RUN wget -O opcua-device-gateway.jar https://resources.cumulocity.com/examples/opc-ua/opcua-device-gateway-${VERSION}.jar
 
 COPY application-tenant.yaml .
 COPY logging.xml .

--- a/containers/opcua-device-gateway/opcua-device-gateway-1018.0.281.jar
+++ b/containers/opcua-device-gateway/opcua-device-gateway-1018.0.281.jar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9b29b286744d03485697889538848f88fbc40ed5e82fd0126b5911b79fcb8f9c
-size 69383560


### PR DESCRIPTION
Build the container using the official jar file downloaded from: https://resources.cumulocity.com/examples/opc-ua/