### PR TITLE
feat: use debian as base image to potentially support armv7 and armv6

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           context: containers/opcua-device-gateway
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM debian:11-slim
 
 ARG BUILDTIME
 ARG REVISION
@@ -15,14 +15,15 @@ LABEL org.opencontainers.image.vendor="thin-edge.io"
 LABEL org.opencontainers.image.licenses="Apache 2.0"
 LABEL org.opencontainers.image.url="https://thin-edge.io"
 LABEL org.opencontainers.image.documentation="https://thin-edge.github.io/thin-edge.io/"
-LABEL org.opencontainers.image.base.name="alpine:3.18"
+LABEL org.opencontainers.image.base.name="debian:11-slim"
 
-RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache bash \
-    && apk add --no-cache --virtual=build-dependencies unzip \
-    && apk add --no-cache curl \
-    && apk add --no-cache openjdk11
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        openjdk-11-jre \
+        wget \
+        bash \
+        unzip \
+        curl
 
 # Only install thin-edge.io to read the tedge config properties (see the entrypoint.sh)
 # TODO: In the future this coupling may be removed


### PR DESCRIPTION
Changing from alpine to a debian-11 base image.

Note: using debian-12 is currently not possible as jre 11 is not available in debian 12.