### PR TITLE
feat: support opcua 1020.x versions

### DIFF
--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -32,7 +32,12 @@ RUN wget -O - thin-edge.io/install.sh | sh -s
 WORKDIR /app
 
 # Download gateway from https://resources.cumulocity.com/examples/opc-ua/
-RUN wget -O opcua-device-gateway.jar https://resources.cumulocity.com/examples/opc-ua/opcua-device-gateway-${VERSION}.jar
+# From opcua version 1020.x.y, the download link changed, so handle both new and old download urls
+RUN case "${VERSION}" in \
+        10[0-1][0-9]*)  DOWNLOAD_URL="https://resources.cumulocity.com/examples/opc-ua/opcua-device-gateway-${VERSION}.jar"  ;; \
+        *)  DOWNLOAD_URL="https://resources.cumulocity.com/examples/opc-ua/${VERSION}/opcua-device-gateway.jar"  ;; \
+    esac \
+    && wget -O opcua-device-gateway.jar "$DOWNLOAD_URL"
 
 COPY application-tenant.yaml .
 COPY logging.xml .

--- a/justfile
+++ b/justfile
@@ -13,3 +13,7 @@ release:
     @echo
     @echo "Created release (tag): {{VERSION}}"
     @echo
+
+# Build the docker image
+build opcua_version *args:
+    docker build -t opcua-device-gateway-image:{{VERSION}} --build-arg VERSION={{opcua_version}} -f containers/opcua-device-gateway/Dockerfile containers/opcua-device-gateway {{args}}


### PR DESCRIPTION
The opcua download urls changed from version 1020.x. Now both the new and old download urls are supported when building an image.

You can try building the image locally using the new build task where you can provide the OPCUA device gateway verison:

```sh
# Old opcua download url
just build 1018.0.308

# New opcua download url
just build 1020.62.0
```

Resolves https://github.com/thin-edge/opcua-device-gateway-container/issues/9
