### PR TITLE
feat: build multiple opcua containers, one per main release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
   # Wait until all other publishing jobs are finished
   # before publishing the virtual packages (which are architecture agnostic)
   publish-containers:
-    name: Publish Containers ${{ matrix.target.opcua_version }}
+    name: Publish ${{ matrix.target.image }} (${{ matrix.target.opcua_version }})
     runs-on: ubuntu-20.04
     env:
       BUILDX_NO_DEFAULT_ATTESTATIONS: 1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - uses: extractions/setup-just@v1
+      - uses: extractions/setup-just@v2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,13 +9,34 @@ jobs:
   # Wait until all other publishing jobs are finished
   # before publishing the virtual packages (which are architecture agnostic)
   publish-containers:
-    name: Publish Containers
+    name: Publish Containers ${{ matrix.target.opcua_version }}
     runs-on: ubuntu-20.04
     env:
       BUILDX_NO_DEFAULT_ATTESTATIONS: 1
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        target:
+          - opcua_version: "1020.62.0"
+            image: opcua-device-gateway-1020
+
+          - opcua_version: "1018.0.308"
+            image: opcua-device-gateway-1018
+        
+          - opcua_version: "1017.0.289"
+            image: opcua-device-gateway-1017
+          
+          - opcua_version: "1016.0.327"
+            image: opcua-device-gateway-1016
+
+          - opcua_version: "1015.0.455"
+            image: opcua-device-gateway-1015
+
+          - opcua_version: "1014.0.413"
+            image: opcua-device-gateway-1014
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,7 +61,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            name=ghcr.io/thin-edge/opcua-device-gateway,enable=true
+            name=ghcr.io/thin-edge/${{ matrix.target.name }},enable=true
           tags: |
             type=raw,value={{tag}}
             type=raw,value=latest
@@ -56,3 +77,4 @@ jobs:
           build-args: |
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            VERSION=${{ matrix.target.opcua_version }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,6 +1,7 @@
 name: publish
 
 on:
+  pull_request:
   push:
     tags:
       - "*"
@@ -17,6 +18,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         target:
           - opcua_version: "1020.62.0"
@@ -61,7 +63,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            name=ghcr.io/thin-edge/${{ matrix.target.name }},enable=true
+            name=ghcr.io/thin-edge/${{ matrix.target.image }},enable=true
           tags: |
             type=raw,value={{tag}}
             type=raw,value=latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
   # Wait until all other publishing jobs are finished
   # before publishing the virtual packages (which are architecture agnostic)
   publish-containers:
-    name: Publish ${{ matrix.target.image }} (${{ matrix.target.opcua_version }})
+    name: ${{ matrix.target.image }} (${{ matrix.target.opcua_version }})
     runs-on: ubuntu-20.04
     env:
       BUILDX_NO_DEFAULT_ATTESTATIONS: 1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,6 +21,11 @@ jobs:
       fail-fast: false
       matrix:
         target:
+          # Keep the "opcua-device-gateway" image on the latest available version
+          # which should align with the Cumulocity version used on the cloud trial tenants (e.g. eu-latest.cumulocity.com)
+          - opcua_version: "1020.62.0"
+            image: opcua-device-gateway
+
           - opcua_version: "1020.62.0"
             image: opcua-device-gateway-1020
 

--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -16,6 +16,7 @@ LABEL org.opencontainers.image.licenses="Apache 2.0"
 LABEL org.opencontainers.image.url="https://thin-edge.io"
 LABEL org.opencontainers.image.documentation="https://thin-edge.github.io/thin-edge.io/"
 LABEL org.opencontainers.image.base.name="debian:11-slim"
+LABEL com.cumulocity.image.opcua.version="$VERSION"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Instead of building the default OPCUA device gateway image, build one container per main version.

For example the following image names are now generated:

* opcua-device-gateway-1013
* opcua-device-gateway-1014
* opcua-device-gateway-1015
* opcua-device-gateway-1016
* opcua-device-gateway-1017
* opcua-device-gateway-1018
* opcua-device-gateway-1020

Where the suffix `-XXXX` is the Cumulocity IoT main version number taken from the latest opcua artifact from the [source](https://resources.cumulocity.com/examples/opc-ua/).