### PR TITLE
feat: Update  to java17 and delete old versions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,19 +27,9 @@ jobs:
 
           - opcua_version: "1023.1.0"
             image: opcua-device-gateway
-            
+
           - opcua_version: "1023.1.0"
             image: opcua-device-gateway-1023
-
-          - opcua_version: "1021.9.7"
-            image: opcua-device-gateway-1021
-
-          - opcua_version: "1020.91.0"
-            image: opcua-device-gateway-1020
-
-          - opcua_version: "1018.531.0"
-            image: opcua-device-gateway-1018
-
 
     steps:
       - name: Checkout

--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:11-slim
+FROM debian:12-slim
 
 ARG BUILDTIME
 ARG REVISION
-ARG VERSION=1021.9.0
+ARG VERSION=1023.1.0
 
 LABEL org.opencontainers.image.title="thin-edge.io"
 LABEL org.opencontainers.image.created=$BUILDTIME
@@ -22,7 +22,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         gpg \
         ca-certificates \
-        openjdk-11-jre \
+        openjdk-17-jre \
         wget \
         bash \
         unzip \

--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.opencontainers.image.vendor="thin-edge.io"
 LABEL org.opencontainers.image.licenses="Apache 2.0"
 LABEL org.opencontainers.image.url="https://thin-edge.io"
 LABEL org.opencontainers.image.documentation="https://thin-edge.github.io/thin-edge.io/"
-LABEL org.opencontainers.image.base.name="debian:11-slim"
+LABEL org.opencontainers.image.base.name="debian:12-slim"
 LABEL com.cumulocity.image.opcua.version="$VERSION"
 
 RUN apt-get update \
@@ -46,5 +46,10 @@ COPY entrypoint.sh .
 ENV OPCUA_GATEWAY_IDENTIFIER=OPCUAGateway
 ENV OPCUA_GATEWAY_NAME=OPCUAGateway
 ENV JAVA_OPTS=
+
+# check compatibility of the jar with the installed java version
+# If the jar is not compatible then java will return quickly with an exit code of 1
+# otherwise if everything is ok, the timeout will kill the app, and it exits with exit code 124
+RUN sh -c 'timeout 4 java -jar opcua-device-gateway.jar; [ $? = 124 ]'
 
 CMD ["/app/entrypoint.sh"]


### PR DESCRIPTION
Updating the base container image Debian 12 and using Java 17 (instead of Java 11). As a result support for older opcua-devicegateway versions is being dropped. All users are encouraged to use the latest 1023.* release.