### PR TITLE
feat: Support connecting to the thin-edge.io local proxy

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,10 +25,10 @@ jobs:
           # Keep the "opcua-device-gateway" image on the latest available version
           # which should align with the Cumulocity version used on the cloud trial tenants (e.g. eu-latest.cumulocity.com)
 
-          - opcua_version: "1023.1.0"
+          - opcua_version: "1023.1.1"
             image: opcua-device-gateway
 
-          - opcua_version: "1023.1.0"
+          - opcua_version: "1023.1.1"
             image: opcua-device-gateway-1023
 
     steps:

--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update \
         wget \
         bash \
         unzip \
-        curl
+        curl \
+        jq
 
 # Only install thin-edge.io to read the tedge config properties (see the entrypoint.sh)
 # TODO: In the future this coupling may be removed

--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 
 # Only install thin-edge.io to read the tedge config properties (see the entrypoint.sh)
 # TODO: In the future this coupling may be removed
-#RUN wget -O - thin-edge.io/install.sh | sh -s
+RUN wget -O - thin-edge.io/install.sh | sh -s
 
 WORKDIR /app
 

--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12-slim
 
 ARG BUILDTIME
 ARG REVISION
-ARG VERSION=1023.1.0
+ARG VERSION=1023.1.1
 
 LABEL org.opencontainers.image.title="thin-edge.io"
 LABEL org.opencontainers.image.created=$BUILDTIME
@@ -30,7 +30,7 @@ RUN apt-get update \
 
 # Only install thin-edge.io to read the tedge config properties (see the entrypoint.sh)
 # TODO: In the future this coupling may be removed
-RUN wget -O - thin-edge.io/install.sh | sh -s
+#RUN wget -O - thin-edge.io/install.sh | sh -s
 
 WORKDIR /app
 

--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -6,13 +6,19 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
     echo "ThinEdge mode enabled, trying to get device_id from c8y over proxy..."
 
         if [ -z "$C8Y_BASEURL" ]; then
-            echo "No C8Y_BASEURL set, setting to localhost thinEdge Proxy only on native"
-            export C8Y_BASEURL=http://127.0.0.1:8001/c8y
+            echo "ERROR: No C8Y_BASEURL set, please define it as an environment variable like export C8Y_BASEURL=http://tedge-container:8001/c8y"
+            exit 1
         fi
 
         if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-            echo "Fetching GATEWAY_THINEDGE_DEVICEID using device user for cumulocity to get device.id http://127.0.0.1:8001/c8y/user/currentUser" 
-            GATEWAY_THINEDGE_DEVICEID="$(curl $C8Y_BASEURL/user/currentUser | jq -r '.id' | cut -d'_' -f2)"
+            echo "Fetching GATEWAY_THINEDGE_DEVICEID using device user for cumulocity to get device.id $C8Y_BASEURL/user/currentUser" 
+            GATEWAY_THINEDGE_DEVICEID="$(curl -sS $C8Y_BASEURL/user/currentUser | jq -r '.id' | cut -d'_' -f2)"
+            
+            if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
+                echo "ERROR: Failed to fetch GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
+                exit 1
+            fi
+            
             echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID" 
             export GATEWAY_THINEDGE_DEVICEID
         fi
@@ -32,7 +38,7 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
 fi
 
 cd /app
-echo "Settings"
+echo "Settings:"
 echo "GATEWAY_IDENTIFIER: $GATEWAY_IDENTIFIER"
 echo "GATEWAY_NAME: $GATEWAY_NAME"
 echo "C8Y_BASEURL: $C8Y_BASEURL"

--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -3,15 +3,19 @@ set -e
 
 # Try loading any values, which aren't already set
 if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
-    echo "ThinEdge mode enabled, trying to get device_id from c8y over proxy..."
+    echo "ThinEdge mode enabled"
 
+    if [ "$GATEWAY_THINEDGE_USEHTTPPROXY" = true ]; then
+        # Proxy mode: C8Y_BASEURL must be set via env var, fetch device ID via curl
+        echo "HTTP Proxy mode enabled"
+        
         if [ -z "$C8Y_BASEURL" ]; then
-            echo "ERROR: No C8Y_BASEURL set, please define it as an environment variable like export C8Y_BASEURL=http://tedge-container:8001/c8y"
+            echo "ERROR: No C8Y_BASEURL set. In proxy mode, please define it as an environment variable (e.g., C8Y_BASEURL=http://tedge-container:8001/c8y)"
             exit 1
         fi
 
         if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-            echo "Fetching GATEWAY_THINEDGE_DEVICEID using device user for cumulocity to get device.id $C8Y_BASEURL/user/currentUser" 
+            echo "Fetching GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser" 
             GATEWAY_THINEDGE_DEVICEID="$(curl -sS $C8Y_BASEURL/user/currentUser | jq -r '.id' | cut -d'_' -f2)"
             
             if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
@@ -22,19 +26,51 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
             echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID" 
             export GATEWAY_THINEDGE_DEVICEID
         fi
+    else
+        # Non-proxy mode: fetch both C8Y_BASEURL and device ID from tedge commands
+        echo "Direct mode (no HTTP proxy), fetching values from tedge config"
+        
+        if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
+            echo "Fetching GATEWAY_THINEDGE_DEVICEID using: tedge config get device.id"
+            GATEWAY_THINEDGE_DEVICEID="$(tedge config get device.id 2>/dev/null ||:)"
+            
+            if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
+                echo "ERROR: Failed to fetch device.id from tedge config"
+                exit 1
+            fi
+            
+            echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID"
+            export GATEWAY_THINEDGE_DEVICEID
+        fi
 
-        # Add a prefix to the OPCUA identifier to ensure its external identity is unique
-        # to allow deploying multiple versions in the fleet without having to define unique names all the time
-        case "$GATEWAY_IDENTIFIER" in
-            *"$GATEWAY_THINEDGE_DEVICEID"*)
-                echo "Gateway identifier already includes the device_id"
-                ;;
-            *)
-                echo "Prefixing GATEWAY_IDENTIFIER with the GATEWAY_THINEDGE_DEVICEID to avoid identity clashes"
-                export GATEWAY_IDENTIFIER="${GATEWAY_THINEDGE_DEVICEID}:${GATEWAY_IDENTIFIER}"
-                ;;
-        esac
-    
+        if [ -z "$C8Y_BASEURL" ] || [ "$C8Y_BASEURL" = "https://" ] || [ "$C8Y_BASEURL" = "http://" ]; then
+            echo "Fetching C8Y_BASEURL using: tedge config get c8y.url"
+            C8Y_URL="$(tedge config get c8y.url 2>&1 ||:)"
+            
+            # Check if the command returned an error message or empty value
+            if [ -z "$C8Y_URL" ] || echo "$C8Y_URL" | grep -q "not set"; then
+                echo "ERROR: c8y.url is not configured in tedge config"
+                exit 1
+            fi
+            
+            C8Y_BASEURL="https://${C8Y_URL}"
+            
+            echo "Got C8Y_BASEURL=$C8Y_BASEURL"
+            export C8Y_BASEURL
+        fi
+    fi
+
+    # Add a prefix to the OPCUA identifier to ensure its external identity is unique
+    # to allow deploying multiple versions in the fleet without having to define unique names all the time
+    case "$GATEWAY_IDENTIFIER" in
+        *"$GATEWAY_THINEDGE_DEVICEID"*)
+            echo "Gateway identifier already includes the device_id"
+            ;;
+        *)
+            echo "Prefixing GATEWAY_IDENTIFIER with the GATEWAY_THINEDGE_DEVICEID to avoid identity clashes"
+            export GATEWAY_IDENTIFIER="${GATEWAY_THINEDGE_DEVICEID}:${GATEWAY_IDENTIFIER}"
+            ;;
+    esac
 fi
 
 cd /app

--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -1,22 +1,20 @@
 #!/bin/sh
 set -e
 
-# Try loading any values, which aren't already set, using tedge cli
+# Try loading any values, which aren't already set
 if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
-    echo "ThinEdge mode enabled, trying to load values from tedge..." >&2
-    if command -V tedge >/dev/null 2>&1; then
-        if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-            echo "Fetching GATEWAY_THINEDGE_DEVICEID using tedge command tedge config get device.id" >&2
-            GATEWAY_THINEDGE_DEVICEID="$(tedge config get device.id 2>/dev/null ||:)"
-            echo "Using value from tedge: GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID" >&2
-            export GATEWAY_THINEDGE_DEVICEID
+    echo "ThinEdge mode enabled, trying to get device_id from c8y over proxy..." >&2
+
+        if [ -z "$C8Y_BASEURL" ]; then
+            echo "No C8Y_BASEURL set, setting to localhost thinEdge Proxy" >&2
+            export C8Y_BASEURL=http://127.0.0.1:8001/c8y
         fi
 
-        if [ -z "$C8Y_BASEURL" ] || [ "$C8Y_BASEURL" = "https://" ] || [ "$C8Y_BASEURL" = "http://" ]; then
-            echo "Fetching C8Y_BASEURL using tedge command tedge config get c8y.url" >&2
-            C8Y_BASEURL="https://$(tedge config get c8y.url 2>/dev/null ||:)"
-            echo "Using value from tedge: C8Y_BASEURL=$C8Y_BASEURL" >&2
-            export C8Y_BASEURL
+        if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
+            echo "Fetching GATEWAY_THINEDGE_DEVICEID using device user for cumulocity to get device.id http://127.0.0.1:8001/c8y/user/currentUser" >&2
+            GATEWAY_THINEDGE_DEVICEID="$(curl $C8Y_BASEURL/user/currentUser | jq -r '.id' | cut -d'_' -f2)"
+            echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID" >&2
+            export GATEWAY_THINEDGE_DEVICEID
         fi
 
         # Add a prefix to the OPCUA identifier to ensure its external identity is unique
@@ -30,7 +28,7 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
                 export GATEWAY_IDENTIFIER="${GATEWAY_THINEDGE_DEVICEID}:${GATEWAY_IDENTIFIER}"
                 ;;
         esac
-    fi
+    
 fi
 
 cd /app

--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -3,17 +3,17 @@ set -e
 
 # Try loading any values, which aren't already set
 if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
-    echo "ThinEdge mode enabled, trying to get device_id from c8y over proxy..." >&2
+    echo "ThinEdge mode enabled, trying to get device_id from c8y over proxy..."
 
         if [ -z "$C8Y_BASEURL" ]; then
-            echo "No C8Y_BASEURL set, setting to localhost thinEdge Proxy" >&2
+            echo "No C8Y_BASEURL set, setting to localhost thinEdge Proxy only on native"
             export C8Y_BASEURL=http://127.0.0.1:8001/c8y
         fi
 
         if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-            echo "Fetching GATEWAY_THINEDGE_DEVICEID using device user for cumulocity to get device.id http://127.0.0.1:8001/c8y/user/currentUser" >&2
+            echo "Fetching GATEWAY_THINEDGE_DEVICEID using device user for cumulocity to get device.id http://127.0.0.1:8001/c8y/user/currentUser" 
             GATEWAY_THINEDGE_DEVICEID="$(curl $C8Y_BASEURL/user/currentUser | jq -r '.id' | cut -d'_' -f2)"
-            echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID" >&2
+            echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID" 
             export GATEWAY_THINEDGE_DEVICEID
         fi
 
@@ -21,10 +21,10 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
         # to allow deploying multiple versions in the fleet without having to define unique names all the time
         case "$GATEWAY_IDENTIFIER" in
             *"$GATEWAY_THINEDGE_DEVICEID"*)
-                echo "Gateway identifier already includes the device_id" >&2
+                echo "Gateway identifier already includes the device_id"
                 ;;
             *)
-                echo "Prefixing GATEWAY_IDENTIFIER with the GATEWAY_THINEDGE_DEVICEID to avoid identity clashes" >&2
+                echo "Prefixing GATEWAY_IDENTIFIER with the GATEWAY_THINEDGE_DEVICEID to avoid identity clashes"
                 export GATEWAY_IDENTIFIER="${GATEWAY_THINEDGE_DEVICEID}:${GATEWAY_IDENTIFIER}"
                 ;;
         esac
@@ -33,9 +33,9 @@ fi
 
 cd /app
 echo "Settings"
-echo "GATEWAY_IDENTIFIER: $GATEWAY_IDENTIFIER" >&2
-echo "GATEWAY_NAME: $GATEWAY_NAME" >&2
-echo "C8Y_BASEURL: $C8Y_BASEURL" >&2
-echo "Starting the opcua-device-gateway..." >&2
+echo "GATEWAY_IDENTIFIER: $GATEWAY_IDENTIFIER"
+echo "GATEWAY_NAME: $GATEWAY_NAME"
+echo "C8Y_BASEURL: $C8Y_BASEURL"
+echo "Starting the opcua-device-gateway..."
 # shellcheck disable=SC2086
 exec /usr/bin/java $JAVA_OPTS -Dlogging.config=file:./logging.xml -Dspring.profiles.active=default -jar opcua-device-gateway.jar "$@"

--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -18,8 +18,9 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
 
         if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
             echo "Fetching GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
-            CURL_RESPONSE="$(curl -sf --connect-timeout 5 --max-time 10 "$C8Y_BASEURL/user/currentUser" 2>/dev/null ||:)"
-            FETCHED_DEVICEID="$(echo "$CURL_RESPONSE" | jq -r '.id // empty' 2>/dev/null | cut -d'_' -f2)"
+            export TEDGE_C8Y_PROXY_CLIENT_HOST=$(echo "$C8Y_BASEURL" | sed  's|http://||g' | sed 's|https://||g' | cut -d: -f1)
+            echo "Set TEDGE_C8Y_PROXY_CLIENT_HOST to $TEDGE_C8Y_PROXY_CLIENT_HOST for tedge http command"
+            FETCHED_DEVICEID="$(tedge http get /c8y/user/currentUser | jq -r '.id' | cut -d'_' -f2-)"
 
             if [ -n "$FETCHED_DEVICEID" ]; then
                 GATEWAY_THINEDGE_DEVICEID="$FETCHED_DEVICEID"

--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-DEVICE_ID_CACHE_FILE="/data/gateway_device_id.cache"
+DEVICE_ID_CACHE_FILE="/app/gateway_device_id.cache"
 
 # Try loading any values, which aren't already set
 if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
@@ -18,10 +18,11 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
 
         if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
             if [ -f "$DEVICE_ID_CACHE_FILE" ]; then
+                echo "Cache hit: reading device ID from $DEVICE_ID_CACHE_FILE"
                 GATEWAY_THINEDGE_DEVICEID="$(cat "$DEVICE_ID_CACHE_FILE")"
                 echo "Loaded GATEWAY_THINEDGE_DEVICEID from cache: $GATEWAY_THINEDGE_DEVICEID"
             else
-                echo "Fetching GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
+                echo "Cache miss ($DEVICE_ID_CACHE_FILE not found), fetching GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
                 GATEWAY_THINEDGE_DEVICEID="$(curl -sS $C8Y_BASEURL/user/currentUser | jq -r '.id' | cut -d'_' -f2)"
 
                 if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
@@ -29,8 +30,9 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
                     exit 1
                 fi
 
-                echo "$GATEWAY_THINEDGE_DEVICEID" > "$DEVICE_ID_CACHE_FILE"
                 echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID"
+                echo "$GATEWAY_THINEDGE_DEVICEID" > "$DEVICE_ID_CACHE_FILE"
+                echo "Cached device ID to $DEVICE_ID_CACHE_FILE"
             fi
             export GATEWAY_THINEDGE_DEVICEID
         fi
@@ -40,10 +42,11 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
         
         if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
             if [ -f "$DEVICE_ID_CACHE_FILE" ]; then
+                echo "Cache hit: reading device ID from $DEVICE_ID_CACHE_FILE"
                 GATEWAY_THINEDGE_DEVICEID="$(cat "$DEVICE_ID_CACHE_FILE")"
                 echo "Loaded GATEWAY_THINEDGE_DEVICEID from cache: $GATEWAY_THINEDGE_DEVICEID"
             else
-                echo "Fetching GATEWAY_THINEDGE_DEVICEID using: tedge config get device.id"
+                echo "Cache miss ($DEVICE_ID_CACHE_FILE not found), fetching GATEWAY_THINEDGE_DEVICEID using: tedge config get device.id"
                 GATEWAY_THINEDGE_DEVICEID="$(tedge config get device.id 2>/dev/null ||:)"
 
                 if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
@@ -51,8 +54,9 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
                     exit 1
                 fi
 
-                echo "$GATEWAY_THINEDGE_DEVICEID" > "$DEVICE_ID_CACHE_FILE"
                 echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID"
+                echo "$GATEWAY_THINEDGE_DEVICEID" > "$DEVICE_ID_CACHE_FILE"
+                echo "Cached device ID to $DEVICE_ID_CACHE_FILE"
             fi
             export GATEWAY_THINEDGE_DEVICEID
         fi

--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+DEVICE_ID_CACHE_FILE="/data/gateway_device_id.cache"
+
 # Try loading any values, which aren't already set
 if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
     echo "ThinEdge mode enabled"
@@ -15,15 +17,21 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
         fi
 
         if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-            echo "Fetching GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser" 
-            GATEWAY_THINEDGE_DEVICEID="$(curl -sS $C8Y_BASEURL/user/currentUser | jq -r '.id' | cut -d'_' -f2)"
-            
-            if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-                echo "ERROR: Failed to fetch GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
-                exit 1
+            if [ -f "$DEVICE_ID_CACHE_FILE" ]; then
+                GATEWAY_THINEDGE_DEVICEID="$(cat "$DEVICE_ID_CACHE_FILE")"
+                echo "Loaded GATEWAY_THINEDGE_DEVICEID from cache: $GATEWAY_THINEDGE_DEVICEID"
+            else
+                echo "Fetching GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
+                GATEWAY_THINEDGE_DEVICEID="$(curl -sS $C8Y_BASEURL/user/currentUser | jq -r '.id' | cut -d'_' -f2)"
+
+                if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
+                    echo "ERROR: Failed to fetch GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
+                    exit 1
+                fi
+
+                echo "$GATEWAY_THINEDGE_DEVICEID" > "$DEVICE_ID_CACHE_FILE"
+                echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID"
             fi
-            
-            echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID" 
             export GATEWAY_THINEDGE_DEVICEID
         fi
     else
@@ -31,15 +39,21 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
         echo "Direct mode (no HTTP proxy), fetching values from tedge config"
         
         if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-            echo "Fetching GATEWAY_THINEDGE_DEVICEID using: tedge config get device.id"
-            GATEWAY_THINEDGE_DEVICEID="$(tedge config get device.id 2>/dev/null ||:)"
-            
-            if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-                echo "ERROR: Failed to fetch device.id from tedge config"
-                exit 1
+            if [ -f "$DEVICE_ID_CACHE_FILE" ]; then
+                GATEWAY_THINEDGE_DEVICEID="$(cat "$DEVICE_ID_CACHE_FILE")"
+                echo "Loaded GATEWAY_THINEDGE_DEVICEID from cache: $GATEWAY_THINEDGE_DEVICEID"
+            else
+                echo "Fetching GATEWAY_THINEDGE_DEVICEID using: tedge config get device.id"
+                GATEWAY_THINEDGE_DEVICEID="$(tedge config get device.id 2>/dev/null ||:)"
+
+                if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
+                    echo "ERROR: Failed to fetch device.id from tedge config"
+                    exit 1
+                fi
+
+                echo "$GATEWAY_THINEDGE_DEVICEID" > "$DEVICE_ID_CACHE_FILE"
+                echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID"
             fi
-            
-            echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID"
             export GATEWAY_THINEDGE_DEVICEID
         fi
 

--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -17,22 +17,24 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
         fi
 
         if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-            if [ -f "$DEVICE_ID_CACHE_FILE" ]; then
-                echo "Cache hit: reading device ID from $DEVICE_ID_CACHE_FILE"
-                GATEWAY_THINEDGE_DEVICEID="$(cat "$DEVICE_ID_CACHE_FILE")"
-                echo "Loaded GATEWAY_THINEDGE_DEVICEID from cache: $GATEWAY_THINEDGE_DEVICEID"
-            else
-                echo "Cache miss ($DEVICE_ID_CACHE_FILE not found), fetching GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
-                GATEWAY_THINEDGE_DEVICEID="$(curl -sS $C8Y_BASEURL/user/currentUser | jq -r '.id' | cut -d'_' -f2)"
+            echo "Fetching GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
+            CURL_RESPONSE="$(curl -sf --connect-timeout 5 --max-time 10 "$C8Y_BASEURL/user/currentUser" 2>/dev/null ||:)"
+            FETCHED_DEVICEID="$(echo "$CURL_RESPONSE" | jq -r '.id // empty' 2>/dev/null | cut -d'_' -f2)"
 
-                if [ -z "$GATEWAY_THINEDGE_DEVICEID" ]; then
-                    echo "ERROR: Failed to fetch GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser"
-                    exit 1
-                fi
-
+            if [ -n "$FETCHED_DEVICEID" ]; then
+                GATEWAY_THINEDGE_DEVICEID="$FETCHED_DEVICEID"
                 echo "Got GATEWAY_THINEDGE_DEVICEID=$GATEWAY_THINEDGE_DEVICEID"
                 echo "$GATEWAY_THINEDGE_DEVICEID" > "$DEVICE_ID_CACHE_FILE"
                 echo "Cached device ID to $DEVICE_ID_CACHE_FILE"
+            else
+                echo "WARNING: Failed to fetch GATEWAY_THINEDGE_DEVICEID from $C8Y_BASEURL/user/currentUser, falling back to cache"
+                if [ -f "$DEVICE_ID_CACHE_FILE" ]; then
+                    GATEWAY_THINEDGE_DEVICEID="$(cat "$DEVICE_ID_CACHE_FILE")"
+                    echo "Loaded GATEWAY_THINEDGE_DEVICEID from cache: $GATEWAY_THINEDGE_DEVICEID"
+                else
+                    echo "ERROR: No cached device ID found at $DEVICE_ID_CACHE_FILE"
+                    exit 1
+                fi
             fi
             export GATEWAY_THINEDGE_DEVICEID
         fi


### PR DESCRIPTION
Introducing the new feature of the opcua-device-gateway to use the local tedge proxy. It is enabled by a new env variable 

GATEWAY_THINEDGE_USEHTTPPROXY=true

I tried to make it compatible with the older version. 
Mainly the endpoint.sh will now check if proxy is enabled. If not it will use the old mechanism to fetch base URL and device id.
