### PR TITLE
ci: add auto version tracking + build/test/promote pipeline with real-c8y integration test

### DIFF
--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -85,15 +85,13 @@ runs:
         # via the Cumulocity REST API using go-c8y-cli, which is already
         # authenticated from C8Y_HOST / C8Y_USER / C8Y_PASSWORD.
         TENANT=$(c8y currenttenant get -n --select name -o csv)
-        sudo cat /etc/tedge/device-certs/tedge-certificate.pem \
+        PAYLOAD=$(sudo cat /etc/tedge/device-certs/tedge-certificate.pem \
           | jq -Rs --arg name "$DEVICE_NAME" \
-              '{name: $name, status: "ENABLED", autoRegistrationEnabled: true, certInPemFormat: .}' \
-          > /tmp/cert-payload.json
+              '{name: $name, status: "ENABLED", autoRegistrationEnabled: true, certInPemFormat: .}')
         c8y api -n POST "/tenant/tenants/${TENANT}/trusted-certificates" \
-          --file /tmp/cert-payload.json \
+          --data "$PAYLOAD" \
           --contentType "application/json" \
           --accept "application/json"
-        rm -f /tmp/cert-payload.json
         echo "TEDGE_TENANT=$TENANT" >> "$GITHUB_ENV"
 
         sudo tedge connect c8y

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -177,20 +177,31 @@ runs:
         fi
 
         echo "Registering OPCSERVER as a child device of OPCUAGateway..."
-        OPCSERVER_DEVICE_ID=$(
+        OPCSERVER_JSON=$(
           wget -qO- https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/opcserver.json \
             | sed "s/###OWNER###/$OWNER/g" \
-            | jq -c . \
-            | c8y inventory children create -n -f --id "$GATEWAY_ID" --childType device --global --template input.value \
-            | jq -r .id
+            | jq -c .
+        )
+        OPCSERVER_DEVICE_ID=$(
+          c8y inventory children create -n -f \
+            --id "$GATEWAY_ID" \
+            --childType device \
+            --global \
+            --data "$OPCSERVER_JSON" \
+          | jq -r .id
         )
         echo "  OPCSERVER id: $OPCSERVER_DEVICE_ID"
 
         echo "Creating Pump01 device protocol..."
-        wget -qO- https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/device-protocols/opcua-pump-device-protocol.json \
-          | sed "s/###OPCSERVER_DEVICE_ID###/$OPCSERVER_DEVICE_ID/g" \
-          | jq -c . \
-          | c8y inventory create -n -f --name Pump01 --type c8y_OpcuaDeviceType --template input.value
+        PUMP_JSON=$(
+          wget -qO- https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/device-protocols/opcua-pump-device-protocol.json \
+            | sed "s/###OPCSERVER_DEVICE_ID###/$OPCSERVER_DEVICE_ID/g" \
+            | jq -c .
+        )
+        c8y inventory create -n -f \
+          --name Pump01 \
+          --type c8y_OpcuaDeviceType \
+          --data "$PUMP_JSON"
 
     - name: Verify Pump01 device was created
       shell: bash

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -28,7 +28,7 @@ runs:
         echo "C8Y_HOST=${{ inputs.c8y_host }}" >> "$GITHUB_ENV"
         echo "C8Y_USER=${{ inputs.c8y_user }}" >> "$GITHUB_ENV"
         echo "C8Y_PASSWORD=${{ inputs.c8y_password }}" >> "$GITHUB_ENV"
-        echo "DEVICE_NAME=test-opcua-${{ github.run_id }}" >> "$GITHUB_ENV"
+        echo "DEVICE_NAME=test-opcua-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
         echo "C8Y_SETTINGS_SESSION_MODE=dev" >> "$GITHUB_ENV"
 
     - name: Install go-c8y-cli

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -88,7 +88,9 @@ runs:
         sudo cat /etc/tedge/device-certs/tedge-certificate.pem \
           | jq -Rs --arg name "$DEVICE_NAME" \
               '{name: $name, status: "ENABLED", autoRegistrationEnabled: true, certInPemFormat: .}' \
-          | c8y api -n POST "/tenant/tenants/${TENANT}/trusted-certificates"
+          | c8y api -n POST "/tenant/tenants/${TENANT}/trusted-certificates" \
+              --contentType "application/json" \
+              --accept "application/json"
         echo "TEDGE_TENANT=$TENANT" >> "$GITHUB_ENV"
 
         sudo tedge connect c8y

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -1,16 +1,30 @@
 name: Integration test
 description: >
   Runs the OPC-UA device gateway integration test against a given image
-  reference. The image must already be available to the runner (either pulled
-  from a remote registry, present in the local Docker daemon, or pullable from
-  a localhost registry service container).
+  reference.
+
+  Approach: install thin-edge.io directly on the runner, connect it to a
+  Cumulocity tenant, then start a single docker-compose stack containing
+  the OPC-UA demo server (`ghcr.io/thin-edge/opc-ua-demo-server:latest`)
+  and the gateway image under test. The gateway uses host.docker.internal
+  to reach the runner's thin-edge MQTT broker. We then register the demo
+  OPC server as a child device of OPCUAGateway, create the Pump01 device
+  protocol, and verify that the corresponding `c8y_OpcuaDevice` managed
+  object appears in Cumulocity.
+
+  No `c8y tedge demo`, no software-repository round-trip, no upstream
+  script.
 
 inputs:
   image:
-    description: Full image ref to test (e.g. localhost:5000/opcua-device-gateway:1.2.3-tedge2.0.1)
+    description: Full image ref of the gateway image to test
     required: true
+  tedge_version:
+    description: thin-edge.io version to install on the runner (matches the version baked into the image)
+    required: false
+    default: ''
   c8y_host:
-    description: Cumulocity host
+    description: Cumulocity host (with or without scheme)
     required: true
   c8y_user:
     description: Cumulocity user
@@ -25,119 +39,200 @@ runs:
     - name: Configure environment
       shell: bash
       run: |
-        echo "C8Y_HOST=${{ inputs.c8y_host }}" >> "$GITHUB_ENV"
+        # Strip scheme from C8Y_HOST so tedge config get / set both work.
+        URL_HOST="${{ inputs.c8y_host }}"
+        URL_HOST="${URL_HOST#https://}"
+        URL_HOST="${URL_HOST#http://}"
+        URL_HOST="${URL_HOST%/}"
+        echo "C8Y_HOST=https://${URL_HOST}" >> "$GITHUB_ENV"
+        echo "C8Y_HOST_PLAIN=${URL_HOST}" >> "$GITHUB_ENV"
         echo "C8Y_USER=${{ inputs.c8y_user }}" >> "$GITHUB_ENV"
         echo "C8Y_PASSWORD=${{ inputs.c8y_password }}" >> "$GITHUB_ENV"
-        echo "DEVICE_NAME=test-opcua-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
+        # Device name must be a valid externalId — keep it short, unique
+        # per run+attempt, and clearly tagged as a CI artefact.
+        echo "DEVICE_NAME=ci-opcua-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
         echo "C8Y_SETTINGS_SESSION_MODE=dev" >> "$GITHUB_ENV"
 
     - name: Install go-c8y-cli
       uses: reubenmiller/setup-go-c8y-cli@v2
 
-    - name: Install c8y-tedge extension
+    - name: Install thin-edge.io on the runner
       shell: bash
-      run: c8y extension install thin-edge/c8y-tedge -n
+      env:
+        TEDGE_VERSION: ${{ inputs.tedge_version }}
+      run: |
+        set -e
+        if [ -n "$TEDGE_VERSION" ]; then
+          curl -fsSL https://thin-edge.io/install.sh | sudo sh -s -- "$TEDGE_VERSION"
+        else
+          curl -fsSL https://thin-edge.io/install.sh | sudo sh -s --
+        fi
+        tedge --version
 
-    - name: Download upstream compose and patch image
+    - name: Configure and connect thin-edge.io to Cumulocity
       shell: bash
       run: |
-        wget -q \
-          https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml \
-          -O patched-gateway-compose.yml
+        set -e
+        # Listen on all interfaces so the gateway container can reach the
+        # runner's mosquitto via host.docker.internal:1883.
+        sudo tedge config set mqtt.bind.address 0.0.0.0
+        sudo tedge config set c8y.url "$C8Y_HOST_PLAIN"
 
-        sed -i \
-          "s|image: ghcr.io/.*/opcua-device-gateway:.*|image: ${{ inputs.image }}|" \
-          patched-gateway-compose.yml
+        sudo tedge cert create --device-id "$DEVICE_NAME"
 
-        echo "--- patched compose ---"
-        cat patched-gateway-compose.yml
+        # tedge cert upload c8y reads the password from stdin when --user is set.
+        printf '%s' "$C8Y_PASSWORD" | sudo tedge cert upload c8y --user "$C8Y_USER"
 
-    - name: Download and patch startOPCDemoContainer.sh
+        sudo tedge connect c8y
+
+        # Capture cert fingerprint for cleanup later.
+        FP=$(sudo tedge cert show 2>/dev/null | awk -F': *' '/Thumbprint|Fingerprint/ {print tolower($2); exit}')
+        echo "TEDGE_CERT_FP=$FP" >> "$GITHUB_ENV"
+
+    - name: Write combined docker-compose.yml
+      shell: bash
+      env:
+        GATEWAY_IMAGE: ${{ inputs.image }}
+      run: |
+        cat > docker-compose.yml <<EOF
+        services:
+          opcserver:
+            image: ghcr.io/thin-edge/opc-ua-demo-server:latest
+            container_name: opcserver
+            restart: always
+            networks: [backend]
+
+          gateway:
+            image: ${GATEWAY_IMAGE}
+            container_name: opc-device-gateway
+            restart: always
+            depends_on: [opcserver]
+            extra_hosts:
+              - host.docker.internal:host-gateway
+            environment:
+              - GATEWAY_IDENTIFIER=OPCUAGateway
+              - GATEWAY_NAME=OPCUAGateway
+              - GATEWAY_THINEDGE_MQTTSERVERURL=tcp://host.docker.internal:1883
+              - GATEWAY_THINEDGE_USEFORDATAFORWARDING=true
+              - GATEWAY_THINEDGE_ENABLED=true
+              - GATEWAY_MAPPINGS_MERGECYCLICREAD=false
+              - GATEWAY_MONITORING_INTERVAL=3600000
+            volumes:
+              - opcua_data:/app/data
+              - /etc/tedge:/etc/tedge
+              - /etc/tedge/device-certs:/etc/tedge/device-certs
+            networks: [backend]
+
+        volumes:
+          opcua_data:
+
+        networks:
+          backend:
+            name: opc-ua-gateway_backend
+        EOF
+        echo "--- docker-compose.yml ---"
+        cat docker-compose.yml
+
+    - name: Start docker-compose stack
       shell: bash
       run: |
-        wget -q \
-          https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/startOPCDemoContainer.sh \
-          -O startOPCDemoContainer.sh
+        docker compose up -d
+        sleep 5
+        docker compose ps
 
-        # Patch 1: replace the gateway compose URL with our locally patched
-        # file, so the freshly built CI image is used.
-        sed -i \
-          's|--url https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml|--file ./patched-gateway-compose.yml|' \
-          startOPCDemoContainer.sh
-
-        # Patch 2: suffix the two shared software names with the run-scoped
-        # DEVICE_NAME so concurrent CI runs cannot collide on the c8y software
-        # repository, and so the cleanup step can delete exactly the entries
-        # this run created without touching any pre-existing demo software.
-        sed -i \
-          -e "s|opcua-server|opcua-server-${DEVICE_NAME}|g" \
-          -e "s|opcua-device-gateway|opcua-device-gateway-${DEVICE_NAME}|g" \
-          startOPCDemoContainer.sh
-
-        echo "--- patched startOPCDemoContainer.sh (head) ---"
-        head -60 startOPCDemoContainer.sh
-
-    - name: Run startOPCDemoContainer.sh
-      # Two notes:
-      # - Stdin is redirected from /dev/null so go-c8y-cli does not see the
-      #   GitHub Actions stdin FIFO as "empty piped input" (which causes the
-      #   `c8y inventory find` / `c8y software find` calls in the upstream
-      #   script to silently no-op with exit codes 3/100). The script's
-      #   internal pipes between c8y calls are unaffected.
-      # - The upstream script has a trailing buggy `sed` after Pump01
-      #   creation that exits non-zero even on success — the Verify step
-      #   below is the source of truth.
-      shell: bash
-      continue-on-error: true
-      run: sh startOPCDemoContainer.sh "$DEVICE_NAME" < /dev/null
-
-    - name: Verify Pump01 device was created (test passed)
+    - name: Wait for OPCUAGateway, register OPCSERVER, create Pump01 protocol
       shell: bash
       run: |
-        PUMP_ID=$(c8y inventory list -n \
-          --type c8y_OpcuaDevice \
-          --owner "device_$DEVICE_NAME" 2>/dev/null | jq -r '.id // empty')
-        if [ -z "$PUMP_ID" ]; then
-          echo "::error::Pump01 device not found — test FAILED"
+        set -e
+        OWNER="device_${DEVICE_NAME}"
+
+        echo "Waiting for OPCUAGateway managed object owned by $OWNER..."
+        GATEWAY_ID=""
+        for i in $(seq 1 60); do
+          GATEWAY_ID=$(c8y inventory find -n --name OPCUAGateway --owner "$OWNER" 2>/dev/null | jq -r '.id // empty' | head -1)
+          if [ -n "$GATEWAY_ID" ] && [ "$GATEWAY_ID" != "null" ]; then
+            echo "  OPCUAGateway found: id=$GATEWAY_ID"
+            break
+          fi
+          echo "  not yet (attempt $i)..."
+          sleep 5
+        done
+        if [ -z "$GATEWAY_ID" ] || [ "$GATEWAY_ID" = "null" ]; then
+          echo "::error::OPCUAGateway never appeared in Cumulocity"
+          docker compose logs gateway | tail -100
           exit 1
         fi
-        echo "Test PASSED — Pump01 device found: $PUMP_ID"
 
-    - name: Cleanup — delete tenant artefacts and stop containers
+        echo "Registering OPCSERVER as a child device of OPCUAGateway..."
+        OPCSERVER_DEVICE_ID=$(
+          wget -qO- https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/opcserver.json \
+            | sed "s/###OWNER###/$OWNER/g" \
+            | c8y inventory children create -n -f --id "$GATEWAY_ID" --childType device --global --template input.value \
+            | jq -r .id
+        )
+        echo "  OPCSERVER id: $OPCSERVER_DEVICE_ID"
+
+        echo "Creating Pump01 device protocol..."
+        wget -qO- https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/device-protocols/opcua-pump-device-protocol.json \
+          | sed "s/###OPCSERVER_DEVICE_ID###/$OPCSERVER_DEVICE_ID/g" \
+          | c8y inventory create -n -f --name Pump01 --type c8y_OpcuaDeviceType --template input.value
+
+    - name: Verify Pump01 device was created
+      shell: bash
+      run: |
+        for i in $(seq 1 60); do
+          PUMP_ID=$(c8y inventory list -n \
+            --type c8y_OpcuaDevice \
+            --owner "device_${DEVICE_NAME}" 2>/dev/null \
+            | jq -r '.id // empty' | head -1)
+          if [ -n "$PUMP_ID" ] && [ "$PUMP_ID" != "null" ]; then
+            echo "Test PASSED — Pump01 device id: $PUMP_ID"
+            exit 0
+          fi
+          echo "Pump01 not yet created (attempt $i)..."
+          sleep 5
+        done
+        echo "::error::Pump01 device was not created"
+        docker compose logs gateway | tail -200
+        exit 1
+
+    - name: Cleanup — disconnect tedge, delete tenant artefacts, stop containers
       if: always()
       shell: bash
       run: |
         set +e
-        echo "--- Cleanup for $DEVICE_NAME ---"
+        echo "--- gateway logs (tail) ---"
+        docker compose logs gateway 2>&1 | tail -50
 
-        # Removes the tedge device, its child devices (Pump01), and the
-        # trusted device certificate in one shot. Also stops the local
-        # docker compose stack.
-        c8y tedge demo delete "$DEVICE_NAME" -n || true
-        c8y tedge demo stop "$DEVICE_NAME" -n || true
+        echo "--- docker compose down ---"
+        docker compose down -v --remove-orphans || true
 
-        # Delete the run-scoped software entries we created. Names match the
-        # sed patch above (`<name>-${DEVICE_NAME}`) so this only ever touches
-        # entries owned by this run. We use `c8y software list` (not `find`,
-        # which is a c8y-tedge alias whose output format we cannot rely on
-        # across versions) and iterate with a here-string so the delete loop
-        # runs in the parent shell (jq | while pipes the loop into a subshell
-        # that swallows errors silently).
-        for SW in "opcua-server-${DEVICE_NAME}" "opcua-device-gateway-${DEVICE_NAME}"; do
-          echo "Looking up software '$SW'..."
-          IDS=$(c8y software list -n --name "$SW" --pageSize 100 \
-            | jq -r '.id // empty')
-          if [ -z "$IDS" ]; then
-            echo "  no software entry found for '$SW'"
-            continue
-          fi
-          while read -r ID; do
-            [ -z "$ID" ] && continue
-            echo "  deleting software '$SW' (id $ID)..."
-            c8y software delete -n --id "$ID" --forceCascade \
+        echo "--- tedge disconnect ---"
+        sudo tedge disconnect c8y || true
+
+        echo "--- delete device from Cumulocity ---"
+        # Resolve external id -> internal id and cascade-delete.
+        EXT_ID=$(c8y identity get -n --type c8y_Serial --name "$DEVICE_NAME" 2>/dev/null | jq -r '.managedObject.id // empty')
+        if [ -n "$EXT_ID" ] && [ "$EXT_ID" != "null" ]; then
+          echo "  deleting device $DEVICE_NAME (mo id $EXT_ID)..."
+          c8y devices delete -n --id "$EXT_ID" --cascade && echo "    deleted." \
+            || echo "::warning::failed to delete device $EXT_ID"
+        else
+          echo "  no device found with externalId $DEVICE_NAME"
+        fi
+
+        echo "--- delete trusted certificate from Cumulocity ---"
+        if [ -n "$TEDGE_CERT_FP" ]; then
+          TENANT_ID=$(c8y currenttenant get -n 2>/dev/null | jq -r '.name // empty')
+          if [ -n "$TENANT_ID" ]; then
+            echo "  removing trusted cert fingerprint $TEDGE_CERT_FP from tenant $TENANT_ID..."
+            c8y api -n DELETE "/tenant/trusted-certificates/$TENANT_ID/$TEDGE_CERT_FP" \
               && echo "    deleted." \
-              || echo "::warning::failed to delete software id $ID"
-          done <<< "$IDS"
-        done
+              || echo "::warning::failed to delete trusted certificate $TEDGE_CERT_FP"
+          fi
+        fi
+
+        echo "--- remove local tedge cert and state ---"
+        sudo rm -f /etc/tedge/device-certs/* || true
 
         echo "--- Cleanup done ---"

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -88,9 +88,7 @@ runs:
         sudo cat /etc/tedge/device-certs/tedge-certificate.pem \
           | jq -Rs --arg name "$DEVICE_NAME" \
               '{name: $name, status: "ENABLED", autoRegistrationEnabled: true, certInPemFormat: .}' \
-          > /tmp/cert-payload.json
-        c8y api -n POST "/tenant/trusted-certificates/${TENANT}" --data "@/tmp/cert-payload.json"
-        rm -f /tmp/cert-payload.json
+          | c8y api -n POST "/tenant/trusted-certificates/${TENANT}"
         echo "TEDGE_TENANT=$TENANT" >> "$GITHUB_ENV"
 
         sudo tedge connect c8y

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -55,32 +55,31 @@ runs:
     - name: Download and patch startOPCDemoContainer.sh
       shell: bash
       run: |
-        UNIQUE_SW_NAME="opcua-device-gateway-ci-${{ github.run_id }}"
-        UNIQUE_OPCUA_SERVER_NAME="opcua-server-ci-${{ github.run_id }}"
-        echo "SW_NAME=$UNIQUE_SW_NAME" >> "$GITHUB_ENV"
-        echo "OPCUA_SERVER_NAME=$UNIQUE_OPCUA_SERVER_NAME" >> "$GITHUB_ENV"
-
         wget -q \
           https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/startOPCDemoContainer.sh \
           -O startOPCDemoContainer.sh
 
-        # Replace the gateway compose URL with our locally patched file.
-        # Must happen BEFORE the renames below so the URL path still matches.
+        # Single deliberate patch: replace the gateway compose URL with our
+        # locally patched file (so the freshly built CI image is used). The
+        # rest of the script runs verbatim — software names, device-type
+        # creation, install steps, cleanup, etc. all stay upstream.
         sed -i \
           's|--url https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml|--file ./patched-gateway-compose.yml|' \
           startOPCDemoContainer.sh
 
-        # Rename gateway software to a unique name to avoid cross-run conflicts.
-        sed -i "s|opcua-device-gateway|${UNIQUE_SW_NAME}|g" startOPCDemoContainer.sh
-        # Same for the opcua-server software (shared name in upstream script).
-        sed -i "s|opcua-server|${UNIQUE_OPCUA_SERVER_NAME}|g" startOPCDemoContainer.sh
-
     - name: Run startOPCDemoContainer.sh
-      # The upstream script has a trailing buggy `sed` after Pump01 creation
-      # that exits non-zero even on success. Verify step is the source of truth.
+      # Two notes:
+      # - Stdin is redirected from /dev/null so go-c8y-cli does not see the
+      #   GitHub Actions stdin FIFO as "empty piped input" (which causes the
+      #   `c8y inventory find` / `c8y software find` calls in the upstream
+      #   script to silently no-op with exit codes 3/100). The script's
+      #   internal pipes between c8y calls are unaffected.
+      # - The upstream script has a trailing buggy `sed` after Pump01
+      #   creation that exits non-zero even on success — the Verify step
+      #   below is the source of truth.
       shell: bash
       continue-on-error: true
-      run: sh startOPCDemoContainer.sh "$DEVICE_NAME"
+      run: sh startOPCDemoContainer.sh "$DEVICE_NAME" < /dev/null
 
     - name: Verify Pump01 device was created (test passed)
       shell: bash
@@ -94,28 +93,23 @@ runs:
         fi
         echo "Test PASSED — Pump01 device found: $PUMP_ID"
 
-    - name: Cleanup — delete all test artifacts
+    - name: Cleanup — delete tenant artefacts and stop containers
       if: always()
       shell: bash
       run: |
         set +e
-        echo "--- Cleanup for run $DEVICE_NAME / $SW_NAME ---"
+        echo "--- Cleanup for $DEVICE_NAME ---"
 
         # Removes the tedge device, its child devices (Pump01), and the
         # trusted device certificate in one shot.
         c8y tedge demo delete "$DEVICE_NAME" -n || true
 
-        # Unique software entries (created this run only)
-        for NAME in "$SW_NAME" "$OPCUA_SERVER_NAME"; do
-          c8y software list -n --name "$NAME" --output json 2>/dev/null \
-            | jq -r '.id // empty' \
-            | while read -r ID; do
-                [ -n "$ID" ] && c8y software delete -n --id "$ID" && \
-                  echo "Deleted software $NAME ($ID)"
-              done
-        done
-
         # Stop the local docker compose stack
         c8y tedge demo stop "$DEVICE_NAME" -n || true
+
+        # Note: shared software entries (`opcua-server`, `opcua-device-gateway`)
+        # are intentionally NOT deleted — the upstream script reuses them
+        # across runs via its idempotent `if [ -z "$(c8y software find ...)" ]`
+        # guards. Deleting them would only force a re-create on the next run.
 
         echo "--- Cleanup done ---"

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -88,7 +88,7 @@ runs:
         sudo cat /etc/tedge/device-certs/tedge-certificate.pem \
           | jq -Rs --arg name "$DEVICE_NAME" \
               '{name: $name, status: "ENABLED", autoRegistrationEnabled: true, certInPemFormat: .}' \
-          | c8y api -n POST "/tenant/trusted-certificates/${TENANT}"
+          | c8y api -n POST "/tenant/tenants/${TENANT}/trusted-certificates"
         echo "TEDGE_TENANT=$TENANT" >> "$GITHUB_ENV"
 
         sudo tedge connect c8y
@@ -233,7 +233,7 @@ runs:
         echo "--- delete trusted certificate from Cumulocity ---"
         if [ -n "$TEDGE_CERT_FP" ] && [ -n "$TEDGE_TENANT" ]; then
           echo "  removing trusted cert fingerprint $TEDGE_CERT_FP from tenant $TEDGE_TENANT..."
-          c8y api -n DELETE "/tenant/trusted-certificates/$TEDGE_TENANT/$TEDGE_CERT_FP" \
+          c8y api -n DELETE "/tenant/tenants/$TEDGE_TENANT/trusted-certificates/$TEDGE_CERT_FP" \
             && echo "    deleted." \
             || echo "::warning::failed to delete trusted certificate $TEDGE_CERT_FP"
         fi

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -88,9 +88,12 @@ runs:
         sudo cat /etc/tedge/device-certs/tedge-certificate.pem \
           | jq -Rs --arg name "$DEVICE_NAME" \
               '{name: $name, status: "ENABLED", autoRegistrationEnabled: true, certInPemFormat: .}' \
-          | c8y api -n POST "/tenant/tenants/${TENANT}/trusted-certificates" \
-              --contentType "application/json" \
-              --accept "application/json"
+          > /tmp/cert-payload.json
+        c8y api -n POST "/tenant/tenants/${TENANT}/trusted-certificates" \
+          --file /tmp/cert-payload.json \
+          --contentType "application/json" \
+          --accept "application/json"
+        rm -f /tmp/cert-payload.json
         echo "TEDGE_TENANT=$TENANT" >> "$GITHUB_ENV"
 
         sudo tedge connect c8y

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -59,13 +59,23 @@ runs:
           https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/startOPCDemoContainer.sh \
           -O startOPCDemoContainer.sh
 
-        # Single deliberate patch: replace the gateway compose URL with our
-        # locally patched file (so the freshly built CI image is used). The
-        # rest of the script runs verbatim — software names, device-type
-        # creation, install steps, cleanup, etc. all stay upstream.
+        # Patch 1: replace the gateway compose URL with our locally patched
+        # file, so the freshly built CI image is used.
         sed -i \
           's|--url https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml|--file ./patched-gateway-compose.yml|' \
           startOPCDemoContainer.sh
+
+        # Patch 2: suffix the two shared software names with the run-scoped
+        # DEVICE_NAME so concurrent CI runs cannot collide on the c8y software
+        # repository, and so the cleanup step can delete exactly the entries
+        # this run created without touching any pre-existing demo software.
+        sed -i \
+          -e "s|opcua-server|opcua-server-${DEVICE_NAME}|g" \
+          -e "s|opcua-device-gateway|opcua-device-gateway-${DEVICE_NAME}|g" \
+          startOPCDemoContainer.sh
+
+        echo "--- patched startOPCDemoContainer.sh (head) ---"
+        head -60 startOPCDemoContainer.sh
 
     - name: Run startOPCDemoContainer.sh
       # Two notes:
@@ -107,9 +117,15 @@ runs:
         # Stop the local docker compose stack
         c8y tedge demo stop "$DEVICE_NAME" -n || true
 
-        # Note: shared software entries (`opcua-server`, `opcua-device-gateway`)
-        # are intentionally NOT deleted — the upstream script reuses them
-        # across runs via its idempotent `if [ -z "$(c8y software find ...)" ]`
-        # guards. Deleting them would only force a re-create on the next run.
+        # Delete the run-scoped software entries we created. Names match the
+        # sed patch above (`<name>-${DEVICE_NAME}`) so this only ever touches
+        # entries owned by this run.
+        for SW in "opcua-server-${DEVICE_NAME}" "opcua-device-gateway-${DEVICE_NAME}"; do
+          c8y software find -n --name "$SW" 2>/dev/null \
+            | jq -r '.id // empty' \
+            | while read -r ID; do
+                [ -n "$ID" ] && c8y software delete -n --id "$ID" --forceCascade || true
+              done
+        done
 
         echo "--- Cleanup done ---"

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -48,9 +48,14 @@ runs:
         echo "C8Y_HOST_PLAIN=${URL_HOST}" >> "$GITHUB_ENV"
         echo "C8Y_USER=${{ inputs.c8y_user }}" >> "$GITHUB_ENV"
         echo "C8Y_PASSWORD=${{ inputs.c8y_password }}" >> "$GITHUB_ENV"
-        # Device name must be a valid externalId — keep it short, unique
-        # per run+attempt, and clearly tagged as a CI artefact.
-        echo "DEVICE_NAME=ci-opcua-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
+        # Run-specific tags so concurrent / repeated runs do not collide on
+        # tenant artefacts. The OPCSERVER hostname must be valid Docker DNS
+        # (lowercase, hyphenated).
+        RUN_TAG="${{ github.run_id }}-${{ github.run_attempt }}"
+        echo "DEVICE_NAME=ci-opcua-${RUN_TAG}" >> "$GITHUB_ENV"
+        echo "OPCSERVER_HOST=opcserver-${RUN_TAG}" >> "$GITHUB_ENV"
+        echo "OPCSERVER_NAME=OPCSERVER-${RUN_TAG}" >> "$GITHUB_ENV"
+        echo "PROTOCOL_NAME=OpcuaPumpProtocol-${RUN_TAG}" >> "$GITHUB_ENV"
         echo "C8Y_SETTINGS_SESSION_MODE=dev" >> "$GITHUB_ENV"
 
     - name: Install go-c8y-cli
@@ -111,13 +116,14 @@ runs:
         services:
           opcserver:
             image: ghcr.io/thin-edge/opc-ua-demo-server:latest
-            container_name: opcserver
+            container_name: ${OPCSERVER_HOST}
+            hostname: ${OPCSERVER_HOST}
             restart: always
             networks: [backend]
 
           gateway:
             image: ${GATEWAY_IMAGE}
-            container_name: opc-device-gateway
+            container_name: opc-device-gateway-${{ github.run_id }}-${{ github.run_attempt }}
             restart: always
             depends_on: [opcserver]
             extra_hosts:
@@ -141,7 +147,7 @@ runs:
 
         networks:
           backend:
-            name: opc-ua-gateway_backend
+            name: opc-ua-gateway_backend-${{ github.run_id }}-${{ github.run_attempt }}
         EOF
         echo "--- docker-compose.yml ---"
         cat docker-compose.yml
@@ -153,8 +159,10 @@ runs:
         sleep 5
         docker compose ps
 
-    - name: Wait for OPCUAGateway, register OPCSERVER, create Pump01 protocol
+    - name: Wait for OPCUAGateway, register OPCSERVER, create device protocol
       shell: bash
+      env:
+        TEMPLATES_DIR: ${{ github.action_path }}/templates
       run: |
         set -e
         OWNER="device_${DEVICE_NAME}"
@@ -176,10 +184,12 @@ runs:
           exit 1
         fi
 
-        echo "Registering OPCSERVER as a child device of OPCUAGateway..."
+        echo "Registering $OPCSERVER_NAME as a child device of OPCUAGateway..."
         OPCSERVER_JSON=$(
-          wget -qO- https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/opcserver.json \
-            | sed "s/###OWNER###/$OWNER/g" \
+          sed -e "s/###OWNER###/${OWNER}/g" \
+              -e "s/###OPCSERVER_NAME###/${OPCSERVER_NAME}/g" \
+              -e "s/###OPCSERVER_HOST###/${OPCSERVER_HOST}/g" \
+              "${TEMPLATES_DIR}/opcserver.json" \
             | jq -c .
         )
         OPCSERVER_DEVICE_ID=$(
@@ -190,35 +200,64 @@ runs:
             --data "$OPCSERVER_JSON" \
           | jq -r .id
         )
-        echo "  OPCSERVER id: $OPCSERVER_DEVICE_ID"
+        echo "  $OPCSERVER_NAME id: $OPCSERVER_DEVICE_ID"
+        echo "OPCSERVER_DEVICE_ID=$OPCSERVER_DEVICE_ID" >> "$GITHUB_ENV"
 
-        echo "Creating Pump01 device protocol..."
+        echo "Creating $PROTOCOL_NAME device protocol..."
         PUMP_JSON=$(
-          wget -qO- https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/device-protocols/opcua-pump-device-protocol.json \
-            | sed "s/###OPCSERVER_DEVICE_ID###/$OPCSERVER_DEVICE_ID/g" \
+          sed -e "s/###OPCSERVER_DEVICE_ID###/${OPCSERVER_DEVICE_ID}/g" \
+              -e "s/###PROTOCOL_NAME###/${PROTOCOL_NAME}/g" \
+              "${TEMPLATES_DIR}/opcua-pump-device-protocol.json" \
             | jq -c .
         )
         c8y inventory create -n -f \
-          --name Pump01 \
+          --name "$PROTOCOL_NAME" \
           --type c8y_OpcuaDeviceType \
           --data "$PUMP_JSON"
 
-    - name: Verify Pump01 device was created
+    - name: Verify Pump01 device was created and measurements arrive
       shell: bash
       run: |
+        set -e
+        OWNER="device_${DEVICE_NAME}"
+
+        echo "Waiting for Pump01 c8y_OpcuaDevice owned by $OWNER..."
+        PUMP_ID=""
         for i in $(seq 1 60); do
           PUMP_ID=$(c8y inventory list -n \
             --type c8y_OpcuaDevice \
-            --owner "device_${DEVICE_NAME}" 2>/dev/null \
+            --owner "$OWNER" 2>/dev/null \
             | jq -r '.id // empty' | head -1)
           if [ -n "$PUMP_ID" ] && [ "$PUMP_ID" != "null" ]; then
-            echo "Test PASSED — Pump01 device id: $PUMP_ID"
-            exit 0
+            echo "  Pump01 device created: id=$PUMP_ID"
+            break
           fi
-          echo "Pump01 not yet created (attempt $i)..."
+          echo "  not yet (attempt $i)..."
           sleep 5
         done
-        echo "::error::Pump01 device was not created"
+        if [ -z "$PUMP_ID" ] || [ "$PUMP_ID" = "null" ]; then
+          echo "::error::Pump01 c8y_OpcuaDevice was not created"
+          docker compose logs gateway | tail -200
+          exit 1
+        fi
+
+        echo "Waiting for measurements on Pump01 ($PUMP_ID)..."
+        DATE_FROM=$(date -u -d '10 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')
+        for i in $(seq 1 60); do
+          MEAS=$(c8y measurements list -n \
+            --device "$PUMP_ID" \
+            --dateFrom "$DATE_FROM" \
+            --pageSize 1 2>/dev/null \
+            | jq -r '.id // empty' | head -1)
+          if [ -n "$MEAS" ] && [ "$MEAS" != "null" ]; then
+            echo "  Measurement received: id=$MEAS"
+            echo "Test PASSED — Pump01 id=$PUMP_ID, measurements arriving."
+            exit 0
+          fi
+          echo "  no measurements yet (attempt $i)..."
+          sleep 5
+        done
+        echo "::error::No measurements arrived on Pump01 within timeout"
         docker compose logs gateway | tail -200
         exit 1
 
@@ -245,6 +284,21 @@ runs:
             || echo "::warning::failed to delete device $EXT_ID"
         else
           echo "  no device found with externalId $DEVICE_NAME"
+        fi
+
+        echo "--- delete device protocol from Cumulocity ---"
+        # The c8y_OpcuaDeviceType MO is standalone (not a child of the device),
+        # so cascade-delete does not catch it.
+        if [ -n "$PROTOCOL_NAME" ]; then
+          PROTO_ID=$(c8y inventory find -n --query "name eq '$PROTOCOL_NAME' and type eq 'c8y_OpcuaDeviceType'" 2>/dev/null \
+            | jq -r '.id // empty' | head -1)
+          if [ -n "$PROTO_ID" ] && [ "$PROTO_ID" != "null" ]; then
+            echo "  deleting device protocol $PROTOCOL_NAME (mo id $PROTO_ID)..."
+            c8y inventory delete -n --id "$PROTO_ID" && echo "    deleted." \
+              || echo "::warning::failed to delete device protocol $PROTO_ID"
+          else
+            echo "  no device protocol found with name $PROTOCOL_NAME"
+          fi
         fi
 
         echo "--- remove local tedge cert and state ---"

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -111,21 +111,33 @@ runs:
         echo "--- Cleanup for $DEVICE_NAME ---"
 
         # Removes the tedge device, its child devices (Pump01), and the
-        # trusted device certificate in one shot.
+        # trusted device certificate in one shot. Also stops the local
+        # docker compose stack.
         c8y tedge demo delete "$DEVICE_NAME" -n || true
-
-        # Stop the local docker compose stack
         c8y tedge demo stop "$DEVICE_NAME" -n || true
 
         # Delete the run-scoped software entries we created. Names match the
         # sed patch above (`<name>-${DEVICE_NAME}`) so this only ever touches
-        # entries owned by this run.
+        # entries owned by this run. We use `c8y software list` (not `find`,
+        # which is a c8y-tedge alias whose output format we cannot rely on
+        # across versions) and iterate with a here-string so the delete loop
+        # runs in the parent shell (jq | while pipes the loop into a subshell
+        # that swallows errors silently).
         for SW in "opcua-server-${DEVICE_NAME}" "opcua-device-gateway-${DEVICE_NAME}"; do
-          c8y software find -n --name "$SW" 2>/dev/null \
-            | jq -r '.id // empty' \
-            | while read -r ID; do
-                [ -n "$ID" ] && c8y software delete -n --id "$ID" --forceCascade || true
-              done
+          echo "Looking up software '$SW'..."
+          IDS=$(c8y software list -n --name "$SW" --pageSize 100 \
+            | jq -r '.id // empty')
+          if [ -z "$IDS" ]; then
+            echo "  no software entry found for '$SW'"
+            continue
+          fi
+          while read -r ID; do
+            [ -z "$ID" ] && continue
+            echo "  deleting software '$SW' (id $ID)..."
+            c8y software delete -n --id "$ID" --forceCascade \
+              && echo "    deleted." \
+              || echo "::warning::failed to delete software id $ID"
+          done <<< "$IDS"
         done
 
         echo "--- Cleanup done ---"

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -80,13 +80,24 @@ runs:
 
         sudo tedge cert create --device-id "$DEVICE_NAME"
 
-        # tedge cert upload c8y reads the password from stdin when --user is set.
-        printf '%s' "$C8Y_PASSWORD" | sudo tedge cert upload c8y --user "$C8Y_USER"
+        # `tedge cert upload c8y` requires an interactive TTY (rpassword
+        # crate, no stdin password support). Upload the certificate directly
+        # via the Cumulocity REST API using go-c8y-cli, which is already
+        # authenticated from C8Y_HOST / C8Y_USER / C8Y_PASSWORD.
+        TENANT=$(c8y currenttenant get -n --select name -o csv)
+        sudo cat /etc/tedge/device-certs/tedge-certificate.pem \
+          | jq -Rs --arg name "$DEVICE_NAME" \
+              '{name: $name, status: "ENABLED", autoRegistrationEnabled: true, certInPemFormat: .}' \
+          > /tmp/cert-payload.json
+        c8y api -n POST "/tenant/trusted-certificates/${TENANT}" --data "@/tmp/cert-payload.json"
+        rm -f /tmp/cert-payload.json
+        echo "TEDGE_TENANT=$TENANT" >> "$GITHUB_ENV"
 
         sudo tedge connect c8y
 
         # Capture cert fingerprint for cleanup later.
-        FP=$(sudo tedge cert show 2>/dev/null | awk -F': *' '/Thumbprint|Fingerprint/ {print tolower($2); exit}')
+        FP=$(sudo tedge cert show 2>/dev/null \
+          | awk -F': *' '/Thumbprint|Fingerprint/ {print tolower($2); exit}')
         echo "TEDGE_CERT_FP=$FP" >> "$GITHUB_ENV"
 
     - name: Write combined docker-compose.yml
@@ -222,14 +233,11 @@ runs:
         fi
 
         echo "--- delete trusted certificate from Cumulocity ---"
-        if [ -n "$TEDGE_CERT_FP" ]; then
-          TENANT_ID=$(c8y currenttenant get -n 2>/dev/null | jq -r '.name // empty')
-          if [ -n "$TENANT_ID" ]; then
-            echo "  removing trusted cert fingerprint $TEDGE_CERT_FP from tenant $TENANT_ID..."
-            c8y api -n DELETE "/tenant/trusted-certificates/$TENANT_ID/$TEDGE_CERT_FP" \
-              && echo "    deleted." \
-              || echo "::warning::failed to delete trusted certificate $TEDGE_CERT_FP"
-          fi
+        if [ -n "$TEDGE_CERT_FP" ] && [ -n "$TEDGE_TENANT" ]; then
+          echo "  removing trusted cert fingerprint $TEDGE_CERT_FP from tenant $TEDGE_TENANT..."
+          c8y api -n DELETE "/tenant/trusted-certificates/$TEDGE_TENANT/$TEDGE_CERT_FP" \
+            && echo "    deleted." \
+            || echo "::warning::failed to delete trusted certificate $TEDGE_CERT_FP"
         fi
 
         echo "--- remove local tedge cert and state ---"

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -69,7 +69,7 @@ runs:
         fi
         tedge --version
 
-    - name: Configure and connect thin-edge.io to Cumulocity
+    - name: Register device with Cumulocity CA and connect thin-edge.io
       shell: bash
       run: |
         set -e
@@ -78,28 +78,29 @@ runs:
         sudo tedge config set mqtt.bind.address 0.0.0.0
         sudo tedge config set c8y.url "$C8Y_HOST_PLAIN"
 
-        sudo tedge cert create --device-id "$DEVICE_NAME"
+        # Make sure the tenant Certificate Authority feature is enabled and
+        # a CA certificate exists. Both calls are idempotent on a tenant that
+        # already has them set up.
+        c8y features enable -n --key certificate-authority || true
+        c8y devicemanagement certificate-authority create -n || true
 
-        # `tedge cert upload c8y` requires an interactive TTY (rpassword
-        # crate, no stdin password support). Upload the certificate directly
-        # via the Cumulocity REST API using go-c8y-cli, which is already
-        # authenticated from C8Y_HOST / C8Y_USER / C8Y_PASSWORD.
-        TENANT=$(c8y currenttenant get -n --select name -o csv)
-        PAYLOAD=$(sudo cat /etc/tedge/device-certs/tedge-certificate.pem \
-          | jq -Rs --arg name "$DEVICE_NAME" \
-              '{name: $name, status: "ENABLED", autoRegistrationEnabled: true, certInPemFormat: .}')
-        c8y api -n POST "/tenant/tenants/${TENANT}/trusted-certificates" \
-          --data "$PAYLOAD" \
-          --contentType "application/json" \
-          --accept "application/json"
-        echo "TEDGE_TENANT=$TENANT" >> "$GITHUB_ENV"
+        # Generate a one-time password and create a CA-based device
+        # registration. The device then downloads a CA-signed certificate;
+        # no per-device trusted-certificate upload is required because the
+        # tenant trusts everything signed by its own CA.
+        OTP=$(openssl rand -hex 12)
+        c8y deviceregistration register-ca -n \
+          --id "$DEVICE_NAME" \
+          --one-time-password "$OTP"
+
+        sudo tedge cert download c8y \
+          --device-id "$DEVICE_NAME" \
+          --one-time-password "$OTP"
 
         sudo tedge connect c8y
 
-        # Capture cert fingerprint for cleanup later.
-        FP=$(sudo tedge cert show 2>/dev/null \
-          | awk -F': *' '/Thumbprint|Fingerprint/ {print tolower($2); exit}')
-        echo "TEDGE_CERT_FP=$FP" >> "$GITHUB_ENV"
+        TENANT=$(c8y currenttenant get -n --select name -o csv)
+        echo "TEDGE_TENANT=$TENANT" >> "$GITHUB_ENV"
 
     - name: Write combined docker-compose.yml
       shell: bash
@@ -179,6 +180,7 @@ runs:
         OPCSERVER_DEVICE_ID=$(
           wget -qO- https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/opcserver.json \
             | sed "s/###OWNER###/$OWNER/g" \
+            | jq -c . \
             | c8y inventory children create -n -f --id "$GATEWAY_ID" --childType device --global --template input.value \
             | jq -r .id
         )
@@ -187,6 +189,7 @@ runs:
         echo "Creating Pump01 device protocol..."
         wget -qO- https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/device-protocols/opcua-pump-device-protocol.json \
           | sed "s/###OPCSERVER_DEVICE_ID###/$OPCSERVER_DEVICE_ID/g" \
+          | jq -c . \
           | c8y inventory create -n -f --name Pump01 --type c8y_OpcuaDeviceType --template input.value
 
     - name: Verify Pump01 device was created
@@ -231,14 +234,6 @@ runs:
             || echo "::warning::failed to delete device $EXT_ID"
         else
           echo "  no device found with externalId $DEVICE_NAME"
-        fi
-
-        echo "--- delete trusted certificate from Cumulocity ---"
-        if [ -n "$TEDGE_CERT_FP" ] && [ -n "$TEDGE_TENANT" ]; then
-          echo "  removing trusted cert fingerprint $TEDGE_CERT_FP from tenant $TEDGE_TENANT..."
-          c8y api -n DELETE "/tenant/tenants/$TEDGE_TENANT/trusted-certificates/$TEDGE_CERT_FP" \
-            && echo "    deleted." \
-            || echo "::warning::failed to delete trusted certificate $TEDGE_CERT_FP"
         fi
 
         echo "--- remove local tedge cert and state ---"

--- a/.github/actions/integration-test/action.yml
+++ b/.github/actions/integration-test/action.yml
@@ -1,0 +1,121 @@
+name: Integration test
+description: >
+  Runs the OPC-UA device gateway integration test against a given image
+  reference. The image must already be available to the runner (either pulled
+  from a remote registry, present in the local Docker daemon, or pullable from
+  a localhost registry service container).
+
+inputs:
+  image:
+    description: Full image ref to test (e.g. localhost:5000/opcua-device-gateway:1.2.3-tedge2.0.1)
+    required: true
+  c8y_host:
+    description: Cumulocity host
+    required: true
+  c8y_user:
+    description: Cumulocity user
+    required: true
+  c8y_password:
+    description: Cumulocity password
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Configure environment
+      shell: bash
+      run: |
+        echo "C8Y_HOST=${{ inputs.c8y_host }}" >> "$GITHUB_ENV"
+        echo "C8Y_USER=${{ inputs.c8y_user }}" >> "$GITHUB_ENV"
+        echo "C8Y_PASSWORD=${{ inputs.c8y_password }}" >> "$GITHUB_ENV"
+        echo "DEVICE_NAME=test-opcua-${{ github.run_id }}" >> "$GITHUB_ENV"
+        echo "C8Y_SETTINGS_SESSION_MODE=dev" >> "$GITHUB_ENV"
+
+    - name: Install go-c8y-cli
+      uses: reubenmiller/setup-go-c8y-cli@v2
+
+    - name: Install c8y-tedge extension
+      shell: bash
+      run: c8y extension install thin-edge/c8y-tedge -n
+
+    - name: Download upstream compose and patch image
+      shell: bash
+      run: |
+        wget -q \
+          https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml \
+          -O patched-gateway-compose.yml
+
+        sed -i \
+          "s|image: ghcr.io/.*/opcua-device-gateway:.*|image: ${{ inputs.image }}|" \
+          patched-gateway-compose.yml
+
+        echo "--- patched compose ---"
+        cat patched-gateway-compose.yml
+
+    - name: Download and patch startOPCDemoContainer.sh
+      shell: bash
+      run: |
+        UNIQUE_SW_NAME="opcua-device-gateway-ci-${{ github.run_id }}"
+        UNIQUE_OPCUA_SERVER_NAME="opcua-server-ci-${{ github.run_id }}"
+        echo "SW_NAME=$UNIQUE_SW_NAME" >> "$GITHUB_ENV"
+        echo "OPCUA_SERVER_NAME=$UNIQUE_OPCUA_SERVER_NAME" >> "$GITHUB_ENV"
+
+        wget -q \
+          https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/startOPCDemoContainer.sh \
+          -O startOPCDemoContainer.sh
+
+        # Replace the gateway compose URL with our locally patched file.
+        # Must happen BEFORE the renames below so the URL path still matches.
+        sed -i \
+          's|--url https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml|--file ./patched-gateway-compose.yml|' \
+          startOPCDemoContainer.sh
+
+        # Rename gateway software to a unique name to avoid cross-run conflicts.
+        sed -i "s|opcua-device-gateway|${UNIQUE_SW_NAME}|g" startOPCDemoContainer.sh
+        # Same for the opcua-server software (shared name in upstream script).
+        sed -i "s|opcua-server|${UNIQUE_OPCUA_SERVER_NAME}|g" startOPCDemoContainer.sh
+
+    - name: Run startOPCDemoContainer.sh
+      # The upstream script has a trailing buggy `sed` after Pump01 creation
+      # that exits non-zero even on success. Verify step is the source of truth.
+      shell: bash
+      continue-on-error: true
+      run: sh startOPCDemoContainer.sh "$DEVICE_NAME"
+
+    - name: Verify Pump01 device was created (test passed)
+      shell: bash
+      run: |
+        PUMP_ID=$(c8y inventory list -n \
+          --type c8y_OpcuaDevice \
+          --owner "device_$DEVICE_NAME" 2>/dev/null | jq -r '.id // empty')
+        if [ -z "$PUMP_ID" ]; then
+          echo "::error::Pump01 device not found — test FAILED"
+          exit 1
+        fi
+        echo "Test PASSED — Pump01 device found: $PUMP_ID"
+
+    - name: Cleanup — delete all test artifacts
+      if: always()
+      shell: bash
+      run: |
+        set +e
+        echo "--- Cleanup for run $DEVICE_NAME / $SW_NAME ---"
+
+        # Removes the tedge device, its child devices (Pump01), and the
+        # trusted device certificate in one shot.
+        c8y tedge demo delete "$DEVICE_NAME" -n || true
+
+        # Unique software entries (created this run only)
+        for NAME in "$SW_NAME" "$OPCUA_SERVER_NAME"; do
+          c8y software list -n --name "$NAME" --output json 2>/dev/null \
+            | jq -r '.id // empty' \
+            | while read -r ID; do
+                [ -n "$ID" ] && c8y software delete -n --id "$ID" && \
+                  echo "Deleted software $NAME ($ID)"
+              done
+        done
+
+        # Stop the local docker compose stack
+        c8y tedge demo stop "$DEVICE_NAME" -n || true
+
+        echo "--- Cleanup done ---"

--- a/.github/actions/integration-test/templates/opcserver.json
+++ b/.github/actions/integration-test/templates/opcserver.json
@@ -1,0 +1,40 @@
+{
+    "c8y_IsDevice": {},
+    "c8y_RequiredAvailability": {
+        "responseInterval": 5
+    },
+    "c8y_ua_ClientConfig": {
+        "alarmSeverityMappings": null,
+        "alarmStatusMappings": null,
+        "autoReconnect": true,
+        "autoScanAddressSpace": true,
+        "certificatePass": null,
+        "cyclicReadBulkSize": 1000,
+        "keystoreBinaryId": null,
+        "keystorePass": null,
+        "maxResponseMessageSize": 50000000,
+        "partialAddressScan": false,
+        "partialAddressScanNodeIds": [],
+        "passwordEncrypted": false,
+        "rescanCron": null,
+        "securityMode": "NONE",
+        "serverUrl": "opc.tcp://###OPCSERVER_HOST###:4840",
+        "statusCheckInterval": 40,
+        "subscribeModelChangeEvent": false,
+        "targetConnectionState": "enabled",
+        "targetUpdateState": false,
+        "timeout": 30,
+        "userIdentityMode": "Anonymous",
+        "userName": "",
+        "userPassword": "",
+        "validateDiscoveredEndpoints": null
+    },
+    "c8y_ua_NamespaceTable": [
+        "http://opcfoundation.org/UA/",
+        "urn:freeopcua:python:server",
+        "http://www.cumulocity.com"
+    ],
+    "name": "###OPCSERVER_NAME###",
+    "owner": "###OWNER###",
+    "type": "c8y_OpcuaServer"
+}

--- a/.github/actions/integration-test/templates/opcua-pump-device-protocol.json
+++ b/.github/actions/integration-test/templates/opcua-pump-device-protocol.json
@@ -1,0 +1,361 @@
+{
+  "com_cumulocity_opcua_common_model_mapping_DeviceType": {
+    "applyConstraints": {
+      "browsePathMatchesRegex": "",
+      "matchesNodeIds": [],
+      "matchesServerIds": [],
+      "serverHasNodeWithValues": null,
+      "serverObjectHasFragment": ""
+    },
+    "description": "Device Type for ###PROTOCOL_NAME###",
+    "enabled": true,
+    "mappings": [
+      {
+        "alarmCreation": null,
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:flow"
+        ],
+        "customAction": null,
+        "eventCreation": null,
+        "measurementCreation": {
+          "fragmentName": "flow",
+          "mappingActionName": "Measurement",
+          "overriddenProcessingMode": null,
+          "series": "flow",
+          "staticFragments": null,
+          "supportedProcessingModes": [
+            "QUIESCENT",
+            "TRANSIENT",
+            "CEP",
+            "PERSISTENT"
+          ],
+          "type": "flow",
+          "unit": "l/m"
+        },
+        "name": "flow",
+        "referencedNodeId": null
+      },
+      {
+        "alarmCreation": null,
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:operatingLevel"
+        ],
+        "customAction": null,
+        "eventCreation": null,
+        "measurementCreation": {
+          "fragmentName": "operatingLevel",
+          "mappingActionName": "Measurement",
+          "overriddenProcessingMode": null,
+          "series": "operatingLevel",
+          "staticFragments": null,
+          "supportedProcessingModes": [
+            "QUIESCENT",
+            "TRANSIENT",
+            "CEP",
+            "PERSISTENT"
+          ],
+          "type": "operatingLevel",
+          "unit": "%"
+        },
+        "name": "operatingLevel",
+        "referencedNodeId": null
+      },
+      {
+        "alarmCreation": null,
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:bearingTemperature"
+        ],
+        "customAction": null,
+        "eventCreation": null,
+        "measurementCreation": {
+          "fragmentName": "bearingTemperature",
+          "mappingActionName": "Measurement",
+          "overriddenProcessingMode": null,
+          "series": "bearingTemperature",
+          "staticFragments": null,
+          "supportedProcessingModes": [
+            "QUIESCENT",
+            "TRANSIENT",
+            "CEP",
+            "PERSISTENT"
+          ],
+          "type": "bearingTemperature",
+          "unit": "c"
+        },
+        "name": "bearingTemperature",
+        "referencedNodeId": null
+      },
+      {
+        "alarmCreation": null,
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:runHours"
+        ],
+        "customAction": null,
+        "eventCreation": null,
+        "measurementCreation": {
+          "fragmentName": "runHours",
+          "mappingActionName": "Measurement",
+          "overriddenProcessingMode": null,
+          "series": "runHours",
+          "staticFragments": null,
+          "supportedProcessingModes": [
+            "QUIESCENT",
+            "TRANSIENT",
+            "CEP",
+            "PERSISTENT"
+          ],
+          "type": "runHours",
+          "unit": "h"
+        },
+        "name": "runHours",
+        "referencedNodeId": null
+      },
+      {
+        "alarmCreation": {
+          "mappingActionName": "Alarm",
+          "overriddenProcessingMode": null,
+          "severity": "CRITICAL",
+          "staticFragments": null,
+          "status": null,
+          "supportedProcessingModes": [
+            "PERSISTENT"
+          ],
+          "text": "Pump in alert state",
+          "type": "pumpAlert"
+        },
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:activeAlarm"
+        ],
+        "customAction": null,
+        "eventCreation": null,
+        "measurementCreation": null,
+        "name": "activeAlarm",
+        "referencedNodeId": null
+      },
+      {
+        "alarmCreation": null,
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:status"
+        ],
+        "customAction": null,
+        "eventCreation": {
+          "mappingActionName": "Event",
+          "overriddenProcessingMode": null,
+          "staticFragments": null,
+          "supportedProcessingModes": [
+            "QUIESCENT",
+            "TRANSIENT",
+            "CEP",
+            "PERSISTENT"
+          ],
+          "text": "Pump state ${value}",
+          "type": "pumpState"
+        },
+        "measurementCreation": null,
+        "name": "status",
+        "referencedNodeId": null
+      },
+      {
+        "alarmCreation": null,
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:inflowTemperature"
+        ],
+        "customAction": null,
+        "eventCreation": null,
+        "measurementCreation": {
+          "fragmentName": "inflowTemperature",
+          "mappingActionName": "Measurement",
+          "overriddenProcessingMode": null,
+          "series": "inflowTemperature",
+          "staticFragments": null,
+          "supportedProcessingModes": [
+            "QUIESCENT",
+            "TRANSIENT",
+            "CEP",
+            "PERSISTENT"
+          ],
+          "type": "inflowTemperature",
+          "unit": "c"
+        },
+        "name": "inflowTemperature",
+        "referencedNodeId": null
+      },
+      {
+        "alarmCreation": null,
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:filterState"
+        ],
+        "customAction": null,
+        "eventCreation": null,
+        "measurementCreation": {
+          "fragmentName": "filterState",
+          "mappingActionName": "Measurement",
+          "overriddenProcessingMode": null,
+          "series": "filterState",
+          "staticFragments": null,
+          "supportedProcessingModes": [
+            "QUIESCENT",
+            "TRANSIENT",
+            "CEP",
+            "PERSISTENT"
+          ],
+          "type": "filterState",
+          "unit": "%"
+        },
+        "name": "filterState",
+        "referencedNodeId": null
+      },
+      {
+        "alarmCreation": null,
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:power"
+        ],
+        "customAction": null,
+        "eventCreation": null,
+        "measurementCreation": {
+          "fragmentName": "power",
+          "mappingActionName": "Measurement",
+          "overriddenProcessingMode": null,
+          "series": "power",
+          "staticFragments": null,
+          "supportedProcessingModes": [
+            "QUIESCENT",
+            "TRANSIENT",
+            "CEP",
+            "PERSISTENT"
+          ],
+          "type": "power",
+          "unit": "W"
+        },
+        "name": "power",
+        "referencedNodeId": null
+      },
+      {
+        "alarmCreation": null,
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:filterDegradationRate"
+        ],
+        "customAction": null,
+        "eventCreation": null,
+        "measurementCreation": null,
+        "name": "filterDegradationRate",
+        "referencedNodeId": null
+      }
+    ],
+    "name": "###PROTOCOL_NAME###",
+    "overriddenSubscriptions": [
+      {
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:operatingLevel"
+        ],
+        "subscriptionType": {
+          "cyclicReadParameters": {
+            "maxAge": 0,
+            "rate": 50,
+            "valid": true
+          },
+          "subscriptionParameters": {
+            "dataChangeTrigger": "StatusValue",
+            "deadbandType": "None",
+            "deadbandValue": null,
+            "discardOldest": true,
+            "queueSize": 10,
+            "ranges": "",
+            "samplingRate": 1000
+          },
+          "type": "Subscription"
+        }
+      },
+      {
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:activeAlarm"
+        ],
+        "subscriptionType": {
+          "cyclicReadParameters": {
+            "maxAge": 0,
+            "rate": 50,
+            "valid": true
+          },
+          "subscriptionParameters": {
+            "dataChangeTrigger": "StatusValue",
+            "deadbandType": "None",
+            "deadbandValue": null,
+            "discardOldest": true,
+            "queueSize": 10,
+            "ranges": "",
+            "samplingRate": 1000
+          },
+          "type": "Subscription"
+        }
+      },
+      {
+        "browsePath": [
+          "http://opcfoundation.org/UA/:Objects",
+          "http://www.cumulocity.com:Pump01",
+          "http://www.cumulocity.com:status"
+        ],
+        "subscriptionType": {
+          "cyclicReadParameters": {
+            "maxAge": 0,
+            "rate": 50,
+            "valid": true
+          },
+          "subscriptionParameters": {
+            "dataChangeTrigger": "StatusValue",
+            "deadbandType": "None",
+            "deadbandValue": null,
+            "discardOldest": true,
+            "queueSize": 10,
+            "ranges": "",
+            "samplingRate": 1000
+          },
+          "type": "Subscription"
+        }
+      }
+    ],
+    "processingMode": null,
+    "referencedNamespaceTable": [
+      "http://opcfoundation.org/UA/",
+      "urn:freeopcua:python:server",
+      "http://www.cumulocity.com"
+    ],
+    "referencedRootNodeId": "nsu=http://opcfoundation.org/UA/;i=84",
+    "referencedServerId": "###OPCSERVER_DEVICE_ID###",
+    "referencedServerName": null,
+    "subscriptionType": {
+      "cyclicReadParameters": {
+        "maxAge": 0,
+        "rate": 3000,
+        "valid": true
+      },
+      "subscriptionParameters": null,
+      "type": "CyclicRead"
+    },
+    "uaEventMappings": null
+  },
+  "type": "c8y_OpcuaDeviceType"
+}

--- a/.github/tracked-versions.json
+++ b/.github/tracked-versions.json
@@ -1,0 +1,4 @@
+{
+    "opcua_version": "1023.2.1",
+    "tedge_version": "2.0.1"
+}

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -15,9 +15,16 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Use a PAT (if available) so that PRs opened by this workflow can
+          # trigger downstream `publish.yaml` runs on `pull_request`. With the
+          # default GITHUB_TOKEN, GitHub suppresses workflow events on
+          # bot-created PRs as a recursion-protection mechanism.
+          token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Get latest OPC-UA version
         id: opcua
@@ -36,18 +43,19 @@ jobs:
       - name: Get latest thinEdge version
         id: tedge
         run: |
-          # Query Cloudsmith API for the latest tedge Debian package (amd64) from tedge-main
-          FULL=$(curl -sf \
-            "https://api.cloudsmith.io/v1/packages/thinedge/tedge-main/?q=name%3Atedge+format%3Adeb+architecture%3Aamd64&page_size=10&sort=-date" \
+          # Query Cloudsmith for the latest tedge Debian package (amd64) from
+          # the official `tedge-release` repo. Use the version string verbatim
+          # — official releases publish clean semver tags (e.g. "1.6.0"), so
+          # no Debian build-metadata stripping is needed.
+          LATEST=$(curl -sf \
+            "https://api.cloudsmith.io/v1/packages/thinedge/tedge-release/?q=name%3Atedge+format%3Adeb+architecture%3Aamd64&page_size=10&sort=-date" \
             | jq -r '[.[] | select(.name == "tedge")] | .[0].version')
-          if [ -z "$FULL" ] || [ "$FULL" = "null" ]; then
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
             echo "::error::Failed to determine latest thinEdge version"
             exit 1
           fi
-          # Strip Debian build metadata — keep only the leading semver (e.g. "2.0.1~109+g36b9024" -> "2.0.1")
-          LATEST=$(echo "$FULL" | sed 's/[~+].*//')
           echo "version=$LATEST" >> "$GITHUB_OUTPUT"
-          echo "Latest thinEdge version: $LATEST (full: $FULL)"
+          echo "Latest thinEdge version: $LATEST"
 
       - name: Read currently tracked versions
         id: current
@@ -91,11 +99,33 @@ jobs:
             > .github/tracked-versions.json
           cat .github/tracked-versions.json
 
-      - name: Commit and push updated versions
+      - name: Open / update pull request with bumped versions
         if: steps.changed.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .github/tracked-versions.json
-          git commit -m "chore: bump versions [opcua=${{ steps.opcua.outputs.version }}, tedge=${{ steps.tedge.outputs.version }}]"
-          git push
+        uses: peter-evans/create-pull-request@v6
+        with:
+          # See note on the checkout step above: WORKFLOW_PAT is required for
+          # the resulting PR to trigger `publish.yaml` via `pull_request`.
+          token: ${{ secrets.WORKFLOW_PAT || secrets.GITHUB_TOKEN }}
+          branch: bot/bump-versions
+          base: main
+          # Re-use the same rolling branch so we always have at most one open
+          # "next candidate versions" PR. Force-update if the previous branch
+          # diverged from main.
+          delete-branch: true
+          commit-message: |
+            chore: bump versions [opcua=${{ steps.opcua.outputs.version }}, tedge=${{ steps.tedge.outputs.version }}]
+          title: "chore: bump versions to opcua=${{ steps.opcua.outputs.version }}, tedge=${{ steps.tedge.outputs.version }}"
+          body: |
+            Automated version bump detected by the `check-versions` workflow.
+
+            | Component | Previous | New |
+            | --- | --- | --- |
+            | OPC-UA   | `${{ steps.current.outputs.opcua }}` | `${{ steps.opcua.outputs.version }}` |
+            | thinEdge | `${{ steps.current.outputs.tedge }}` | `${{ steps.tedge.outputs.version }}` |
+
+            The `publish.yaml` workflow will build the CI image and run the integration test against this PR. Merge once the checks are green to promote the new versions to `main`.
+          labels: |
+            automated
+            version-bump
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/check-versions.yaml
+++ b/.github/workflows/check-versions.yaml
@@ -1,0 +1,101 @@
+name: Check for new versions
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
+  workflow_dispatch:
+
+# Serialize with publish + test-integration so only one workflow runs at a time.
+concurrency:
+  group: opcua-gateway-ci
+  cancel-in-progress: false
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get latest OPC-UA version
+        id: opcua
+        run: |
+          LATEST=$(curl -sf https://resources.cumulocity.com/examples/opc-ua/ \
+            | grep -oP '(?<=href=")[0-9]+\.[0-9]+\.[0-9]+(?=/)' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            | tail -1)
+          if [ -z "$LATEST" ]; then
+            echo "::error::Failed to determine latest OPC-UA version"
+            exit 1
+          fi
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Latest OPC-UA version: $LATEST"
+
+      - name: Get latest thinEdge version
+        id: tedge
+        run: |
+          # Query Cloudsmith API for the latest tedge Debian package (amd64) from tedge-main
+          FULL=$(curl -sf \
+            "https://api.cloudsmith.io/v1/packages/thinedge/tedge-main/?q=name%3Atedge+format%3Adeb+architecture%3Aamd64&page_size=10&sort=-date" \
+            | jq -r '[.[] | select(.name == "tedge")] | .[0].version')
+          if [ -z "$FULL" ] || [ "$FULL" = "null" ]; then
+            echo "::error::Failed to determine latest thinEdge version"
+            exit 1
+          fi
+          # Strip Debian build metadata — keep only the leading semver (e.g. "2.0.1~109+g36b9024" -> "2.0.1")
+          LATEST=$(echo "$FULL" | sed 's/[~+].*//')
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Latest thinEdge version: $LATEST (full: $FULL)"
+
+      - name: Read currently tracked versions
+        id: current
+        run: |
+          if [ -f .github/tracked-versions.json ]; then
+            OPCUA=$(jq -r '.opcua_version // ""' .github/tracked-versions.json)
+            TEDGE=$(jq -r '.tedge_version // ""' .github/tracked-versions.json)
+          else
+            OPCUA=""
+            TEDGE=""
+          fi
+          echo "opcua=$OPCUA" >> "$GITHUB_OUTPUT"
+          echo "tedge=$TEDGE" >> "$GITHUB_OUTPUT"
+          echo "Currently tracked OPC-UA version: $OPCUA"
+          echo "Currently tracked thinEdge version: $TEDGE"
+
+      - name: Detect version changes
+        id: changed
+        run: |
+          NEW_OPCUA="${{ steps.opcua.outputs.version }}"
+          NEW_TEDGE="${{ steps.tedge.outputs.version }}"
+          CUR_OPCUA="${{ steps.current.outputs.opcua }}"
+          CUR_TEDGE="${{ steps.current.outputs.tedge }}"
+          if [ "$NEW_OPCUA" != "$CUR_OPCUA" ] || [ "$NEW_TEDGE" != "$CUR_TEDGE" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version change detected:"
+            echo "  OPC-UA:   $CUR_OPCUA -> $NEW_OPCUA"
+            echo "  thinEdge: $CUR_TEDGE -> $NEW_TEDGE"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No version changes detected."
+          fi
+
+      - name: Update tracked-versions.json
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          jq -n \
+            --arg opcua "${{ steps.opcua.outputs.version }}" \
+            --arg tedge "${{ steps.tedge.outputs.version }}" \
+            '{opcua_version: $opcua, tedge_version: $tedge}' \
+            > .github/tracked-versions.json
+          cat .github/tracked-versions.json
+
+      - name: Commit and push updated versions
+        if: steps.changed.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/tracked-versions.json
+          git commit -m "chore: bump versions [opcua=${{ steps.opcua.outputs.version }}, tedge=${{ steps.tedge.outputs.version }}]"
+          git push

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,10 +33,12 @@ concurrency:
 jobs:
   build-and-test:
     name: Build (amd64) + integration test against local registry
-    # Skip on forked PRs — required C8Y_* secrets aren't available there.
+    # Skip on PRs coming from an external fork — required C8Y_* secrets aren't
+    # available there. Same-repo PRs (including from a branch in this repo
+    # back to its own main) still run.
     if: >-
       github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.fork == false
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     # Local Docker registry on the runner. We push the freshly built CI
     # image here and pull it from docker compose during the test, so no

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,34 +2,48 @@ name: publish
 
 on:
   workflow_dispatch:
-  pull_request:
+    inputs:
+      opcua_version:
+        description: 'OPC-UA gateway version (leave empty to use tracked-versions.json)'
+        required: false
+      tedge_version:
+        description: 'thinEdge version (leave empty to use tracked-versions.json)'
+        required: false
   push:
-    tags:
-      - "*"
+    branches:
+      - main
+    paths:
+      - '.github/tracked-versions.json'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'containers/opcua-device-gateway/**'
+      - '.github/tracked-versions.json'
+      - '.github/workflows/publish.yaml'
+      - '.github/workflows/test-integration.yaml'
+
+# Only one publish (and one test-integration / check-versions) at a time.
+# Per-PR concurrency so a new push to the same PR cancels the previous run.
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('opcua-gateway-ci-pr-{0}', github.event.pull_request.number) || 'opcua-gateway-ci' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Wait until all other publishing jobs are finished
-  # before publishing the virtual packages (which are architecture agnostic)
-  publish-containers:
-    name: ${{ matrix.target.image }} (${{ matrix.target.opcua_version }})
+  build:
+    name: Build CI image
     runs-on: ubuntu-24.04
     env:
       BUILDX_NO_DEFAULT_ATTESTATIONS: 1
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          # Keep the "opcua-device-gateway" image on the latest available version
-          # which should align with the Cumulocity version used on the cloud trial tenants (e.g. eu-latest.cumulocity.com)
-
-          - opcua_version: "1023.1.1"
-            image: opcua-device-gateway
-
-          - opcua_version: "1023.1.1"
-            image: opcua-device-gateway-1023
+    outputs:
+      ci_image: ${{ steps.tags.outputs.ci_image }}
+      ci_tag: ${{ steps.tags.outputs.ci_tag }}
+      version_tag: ${{ steps.versions.outputs.image_tag }}
+      opcua_version: ${{ steps.versions.outputs.opcua_version }}
+      tedge_version: ${{ steps.versions.outputs.tedge_version }}
 
     steps:
       - name: Checkout
@@ -37,7 +51,32 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - uses: extractions/setup-just@v2
+
+      - name: Resolve versions
+        id: versions
+        run: |
+          OPCUA_VERSION="${{ inputs.opcua_version }}"
+          TEDGE_VERSION="${{ inputs.tedge_version }}"
+          if [ -z "$OPCUA_VERSION" ] || [ -z "$TEDGE_VERSION" ]; then
+            OPCUA_VERSION=$(jq -r '.opcua_version' .github/tracked-versions.json)
+            TEDGE_VERSION=$(jq -r '.tedge_version' .github/tracked-versions.json)
+          fi
+          TEDGE_TAG=$(echo "$TEDGE_VERSION" | sed 's/[~+]/-/g')
+          echo "opcua_version=$OPCUA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tedge_version=$TEDGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${OPCUA_VERSION}-tedge${TEDGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "OPC-UA version:   $OPCUA_VERSION"
+          echo "thinEdge version: $TEDGE_VERSION"
+          echo "Version tag:      ${OPCUA_VERSION}-tedge${TEDGE_TAG}"
+
+      - name: Compute CI tag
+        id: tags
+        run: |
+          CI_TAG="ci-${{ github.run_id }}"
+          CI_IMAGE="ghcr.io/${{ github.repository_owner }}/opcua-device-gateway:${CI_TAG}"
+          echo "ci_tag=${CI_TAG}" >> "$GITHUB_OUTPUT"
+          echo "ci_image=${CI_IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "CI image: ${CI_IMAGE}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -50,25 +89,93 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker meta
+      - name: Docker meta (CI tag only)
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            name=ghcr.io/${{ github.repository_owner }}/${{ matrix.target.image }},enable=true
+            name=ghcr.io/${{ github.repository_owner }}/opcua-device-gateway,enable=true
           tags: |
-            type=raw,value={{tag}}
-            type=raw,value=latest
+            type=raw,value=${{ steps.tags.outputs.ci_tag }}
 
-      - name: Build and push
+      - name: Build and push CI image
         uses: docker/build-push-action@v5
         with:
           context: containers/opcua-device-gateway
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-            VERSION=${{ matrix.target.opcua_version }}
+            VERSION=${{ steps.versions.outputs.opcua_version }}
+            TEDGE_VERSION=${{ steps.versions.outputs.tedge_version }}
+
+  test:
+    name: Integration test
+    needs: build
+    uses: ./.github/workflows/test-integration.yaml
+    with:
+      image: ${{ needs.build.outputs.ci_image }}
+    secrets: inherit
+
+  promote:
+    name: Promote CI image to version + latest
+    needs: [build, test]
+    # Don't promote on PRs — only on main / dispatch
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    steps:
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Re-tag CI image as version + latest (no rebuild)
+        run: |
+          SRC="${{ needs.build.outputs.ci_image }}"
+          REPO="ghcr.io/${{ github.repository_owner }}/opcua-device-gateway"
+          VERSION_TAG="${{ needs.build.outputs.version_tag }}"
+          docker buildx imagetools create \
+            --tag "${REPO}:${VERSION_TAG}" \
+            --tag "${REPO}:latest" \
+            "${SRC}"
+          echo "Promoted ${SRC} -> ${REPO}:${VERSION_TAG}, ${REPO}:latest"
+
+  cleanup-ci-tag:
+    name: Delete CI tag from registry
+    needs: [build, test, promote]
+    # Run if build succeeded, even when test failed or promote was skipped (PRs).
+    if: always() && needs.build.result == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    steps:
+      - name: Delete ci-<run_id> tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PKG: opcua-device-gateway
+          CI_TAG: ${{ needs.build.outputs.ci_tag }}
+        run: |
+          set +e
+          for ENDPOINT in \
+              "/orgs/${OWNER}/packages/container/${PKG}/versions" \
+              "/users/${OWNER}/packages/container/${PKG}/versions"; do
+            VERSION_ID=$(gh api --paginate "$ENDPOINT" \
+              --jq ".[] | select(.metadata.container.tags[]? == \"${CI_TAG}\") | .id" \
+              2>/dev/null | head -1)
+            if [ -n "$VERSION_ID" ]; then
+              gh api -X DELETE "${ENDPOINT}/${VERSION_ID}" \
+                && echo "Deleted ${CI_TAG} (version id=${VERSION_ID}) via ${ENDPOINT}" \
+                && exit 0
+            fi
+          done
+          echo "::warning::Could not find or delete ${CI_TAG} in registry"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,16 +12,17 @@ on:
   push:
     branches:
       - main
-    paths:
-      - '.github/tracked-versions.json'
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - 'docs/**'
   pull_request:
     branches:
       - main
-    paths:
-      - 'containers/opcua-device-gateway/**'
-      - '.github/tracked-versions.json'
-      - '.github/workflows/publish.yaml'
-      - '.github/workflows/test-integration.yaml'
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - 'docs/**'
 
 # Only one publish (and one test-integration / check-versions) at a time.
 # Per-PR concurrency so a new push to the same PR cancels the previous run.
@@ -30,20 +31,31 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    name: Build CI image
+  build-and-test:
+    name: Build (amd64) + integration test against local registry
+    # Skip on forked PRs — required C8Y_* secrets aren't available there.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-24.04
+    # Local Docker registry on the runner. We push the freshly built CI
+    # image here and pull it from docker compose during the test, so no
+    # CI-only image ever lands on ghcr.io.
+    # See https://docs.docker.com/build/ci/github-actions/local-registry/
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     env:
       BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+      LOCAL_REGISTRY: localhost:5000
     permissions:
       contents: read
-      packages: write
     outputs:
-      ci_image: ${{ steps.tags.outputs.ci_image }}
-      ci_tag: ${{ steps.tags.outputs.ci_tag }}
-      version_tag: ${{ steps.versions.outputs.image_tag }}
       opcua_version: ${{ steps.versions.outputs.opcua_version }}
       tedge_version: ${{ steps.versions.outputs.tedge_version }}
+      version_tag: ${{ steps.versions.outputs.image_tag }}
 
     steps:
       - name: Checkout
@@ -55,28 +67,85 @@ jobs:
       - name: Resolve versions
         id: versions
         run: |
+          # Each input is resolved independently from tracked-versions.json
+          # so that workflow_dispatch can override only one of them.
           OPCUA_VERSION="${{ inputs.opcua_version }}"
           TEDGE_VERSION="${{ inputs.tedge_version }}"
-          if [ -z "$OPCUA_VERSION" ] || [ -z "$TEDGE_VERSION" ]; then
+          if [ -z "$OPCUA_VERSION" ]; then
             OPCUA_VERSION=$(jq -r '.opcua_version' .github/tracked-versions.json)
+          fi
+          if [ -z "$TEDGE_VERSION" ]; then
             TEDGE_VERSION=$(jq -r '.tedge_version' .github/tracked-versions.json)
           fi
           TEDGE_TAG=$(echo "$TEDGE_VERSION" | sed 's/[~+]/-/g')
+          IMAGE_TAG="${OPCUA_VERSION}-tedge${TEDGE_TAG}"
+          CI_IMAGE="${LOCAL_REGISTRY}/opcua-device-gateway:${IMAGE_TAG}"
           echo "opcua_version=$OPCUA_VERSION" >> "$GITHUB_OUTPUT"
           echo "tedge_version=$TEDGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "image_tag=${OPCUA_VERSION}-tedge${TEDGE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "ci_image=$CI_IMAGE" >> "$GITHUB_OUTPUT"
           echo "OPC-UA version:   $OPCUA_VERSION"
           echo "thinEdge version: $TEDGE_VERSION"
-          echo "Version tag:      ${OPCUA_VERSION}-tedge${TEDGE_TAG}"
+          echo "Local CI image:   $CI_IMAGE"
 
-      - name: Compute CI tag
-        id: tags
-        run: |
-          CI_TAG="ci-${{ github.run_id }}"
-          CI_IMAGE="ghcr.io/${{ github.repository_owner }}/opcua-device-gateway:${CI_TAG}"
-          echo "ci_tag=${CI_TAG}" >> "$GITHUB_OUTPUT"
-          echo "ci_image=${CI_IMAGE}" >> "$GITHUB_OUTPUT"
-          echo "CI image: ${CI_IMAGE}"
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          # Required so the builder container can reach the registry service
+          # listening on the runner's localhost:5000.
+          driver-opts: network=host
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.LOCAL_REGISTRY }}/opcua-device-gateway
+          tags: |
+            type=raw,value=${{ steps.versions.outputs.image_tag }}
+
+      - name: Build and push CI image to local registry (amd64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: containers/opcua-device-gateway
+          push: true
+          # Single-arch is enough for CI: the runner can only execute amd64.
+          # The full multi-arch image is built fresh in the `publish` job
+          # against ghcr.io on `main` / dispatch.
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+            VERSION=${{ steps.versions.outputs.opcua_version }}
+            TEDGE_VERSION=${{ steps.versions.outputs.tedge_version }}
+
+      - name: Run integration test
+        uses: ./.github/actions/integration-test
+        with:
+          image: ${{ steps.versions.outputs.ci_image }}
+          c8y_host: ${{ secrets.C8Y_HOST }}
+          c8y_user: ${{ secrets.C8Y_USER }}
+          c8y_password: ${{ secrets.C8Y_PASSWORD }}
+
+  publish:
+    name: Publish multi-arch image to ghcr.io
+    needs: build-and-test
+    # Only on main / dispatch — never on PRs.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    env:
+      BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -89,16 +158,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker meta (CI tag only)
+      - name: Compute immutable build suffix
+        id: build
+        run: |
+          # Date (UTC) + short commit SHA gives a human-readable, always-unique
+          # tag suffix even if the same `<version_tag>` is built more than once
+          # in a single day (e.g. two container-only fixes merged on the same
+          # day). The plain `<version_tag>` and `latest` keep rolling forward.
+          DATE=$(date -u +%Y%m%d)
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          echo "suffix=${DATE}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Immutable build suffix: ${DATE}-${SHORT_SHA}"
+
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            name=ghcr.io/${{ github.repository_owner }}/opcua-device-gateway,enable=true
+          images: ghcr.io/${{ github.repository_owner }}/opcua-device-gateway
           tags: |
-            type=raw,value=${{ steps.tags.outputs.ci_tag }}
+            type=raw,value=${{ needs.build-and-test.outputs.version_tag }}
+            type=raw,value=${{ needs.build-and-test.outputs.version_tag }}-${{ steps.build.outputs.suffix }}
+            type=raw,value=latest
 
-      - name: Build and push CI image
+      - name: Build and push multi-arch image
         uses: docker/build-push-action@v5
         with:
           context: containers/opcua-device-gateway
@@ -109,73 +191,5 @@ jobs:
           build-args: |
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
-            VERSION=${{ steps.versions.outputs.opcua_version }}
-            TEDGE_VERSION=${{ steps.versions.outputs.tedge_version }}
-
-  test:
-    name: Integration test
-    needs: build
-    uses: ./.github/workflows/test-integration.yaml
-    with:
-      image: ${{ needs.build.outputs.ci_image }}
-    secrets: inherit
-
-  promote:
-    name: Promote CI image to version + latest
-    needs: [build, test]
-    # Don't promote on PRs — only on main / dispatch
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-24.04
-    permissions:
-      packages: write
-    steps:
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Re-tag CI image as version + latest (no rebuild)
-        run: |
-          SRC="${{ needs.build.outputs.ci_image }}"
-          REPO="ghcr.io/${{ github.repository_owner }}/opcua-device-gateway"
-          VERSION_TAG="${{ needs.build.outputs.version_tag }}"
-          docker buildx imagetools create \
-            --tag "${REPO}:${VERSION_TAG}" \
-            --tag "${REPO}:latest" \
-            "${SRC}"
-          echo "Promoted ${SRC} -> ${REPO}:${VERSION_TAG}, ${REPO}:latest"
-
-  cleanup-ci-tag:
-    name: Delete CI tag from registry
-    needs: [build, test, promote]
-    # Run if build succeeded, even when test failed or promote was skipped (PRs).
-    if: always() && needs.build.result == 'success'
-    runs-on: ubuntu-24.04
-    permissions:
-      packages: write
-    steps:
-      - name: Delete ci-<run_id> tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OWNER: ${{ github.repository_owner }}
-          PKG: opcua-device-gateway
-          CI_TAG: ${{ needs.build.outputs.ci_tag }}
-        run: |
-          set +e
-          for ENDPOINT in \
-              "/orgs/${OWNER}/packages/container/${PKG}/versions" \
-              "/users/${OWNER}/packages/container/${PKG}/versions"; do
-            VERSION_ID=$(gh api --paginate "$ENDPOINT" \
-              --jq ".[] | select(.metadata.container.tags[]? == \"${CI_TAG}\") | .id" \
-              2>/dev/null | head -1)
-            if [ -n "$VERSION_ID" ]; then
-              gh api -X DELETE "${ENDPOINT}/${VERSION_ID}" \
-                && echo "Deleted ${CI_TAG} (version id=${VERSION_ID}) via ${ENDPOINT}" \
-                && exit 0
-            fi
-          done
-          echo "::warning::Could not find or delete ${CI_TAG} in registry"
+            VERSION=${{ needs.build-and-test.outputs.opcua_version }}
+            TEDGE_VERSION=${{ needs.build-and-test.outputs.tedge_version }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,32 +32,26 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: Build (amd64) + integration test against local registry
-    # Skip on PRs coming from an external fork — required C8Y_* secrets aren't
-    # available there. Same-repo PRs (including from a branch in this repo
-    # back to its own main) still run.
+    name: Build (amd64) + integration test on ghcr.io CI tag
+    # Skip on PRs coming from an external fork — required C8Y_* secrets and a
+    # writable GITHUB_TOKEN aren't available there. Same-repo PRs (including
+    # from a branch in this repo back to its own main) still run.
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
-    # Local Docker registry on the runner. We push the freshly built CI
-    # image here and pull it from docker compose during the test, so no
-    # CI-only image ever lands on ghcr.io.
-    # See https://docs.docker.com/build/ci/github-actions/local-registry/
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     env:
       BUILDX_NO_DEFAULT_ATTESTATIONS: 1
-      LOCAL_REGISTRY: localhost:5000
     permissions:
       contents: read
+      # Needed to push the temporary CI tag to ghcr.io and to delete it again
+      # in the cleanup step below.
+      packages: write
     outputs:
       opcua_version: ${{ steps.versions.outputs.opcua_version }}
       tedge_version: ${{ steps.versions.outputs.tedge_version }}
       version_tag: ${{ steps.versions.outputs.image_tag }}
+      ci_tag: ${{ steps.versions.outputs.ci_tag }}
 
     steps:
       - name: Checkout
@@ -81,31 +75,41 @@ jobs:
           fi
           TEDGE_TAG=$(echo "$TEDGE_VERSION" | sed 's/[~+]/-/g')
           IMAGE_TAG="${OPCUA_VERSION}-tedge${TEDGE_TAG}"
-          CI_IMAGE="${LOCAL_REGISTRY}/opcua-device-gateway:${IMAGE_TAG}"
+          # Temporary, throwaway tag used only for the integration test. It
+          # is pushed to ghcr.io because podman running inside the gateway
+          # container under test cannot reach a docker registry bound to the
+          # runner's localhost. The tag is deleted again in the cleanup step.
+          CI_TAG="ci-${{ github.run_id }}-${{ github.run_attempt }}"
+          CI_IMAGE="ghcr.io/${{ github.repository_owner }}/opcua-device-gateway:${CI_TAG}"
           echo "opcua_version=$OPCUA_VERSION" >> "$GITHUB_OUTPUT"
           echo "tedge_version=$TEDGE_VERSION" >> "$GITHUB_OUTPUT"
           echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "ci_tag=$CI_TAG" >> "$GITHUB_OUTPUT"
           echo "ci_image=$CI_IMAGE" >> "$GITHUB_OUTPUT"
           echo "OPC-UA version:   $OPCUA_VERSION"
           echo "thinEdge version: $TEDGE_VERSION"
-          echo "Local CI image:   $CI_IMAGE"
+          echo "Final image tag:  $IMAGE_TAG"
+          echo "CI image (temp):  $CI_IMAGE"
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          # Required so the builder container can reach the registry service
-          # listening on the runner's localhost:5000.
-          driver-opts: network=host
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.LOCAL_REGISTRY }}/opcua-device-gateway
+          images: ghcr.io/${{ github.repository_owner }}/opcua-device-gateway
           tags: |
-            type=raw,value=${{ steps.versions.outputs.image_tag }}
+            type=raw,value=${{ steps.versions.outputs.ci_tag }}
 
-      - name: Build and push CI image to local registry (amd64 only)
+      - name: Build and push CI image to ghcr.io (amd64 only)
         uses: docker/build-push-action@v5
         with:
           context: containers/opcua-device-gateway
@@ -129,6 +133,38 @@ jobs:
           c8y_host: ${{ secrets.C8Y_HOST }}
           c8y_user: ${{ secrets.C8Y_USER }}
           c8y_password: ${{ secrets.C8Y_PASSWORD }}
+
+      - name: Delete temporary CI tag from ghcr.io
+        if: always() && steps.versions.outputs.ci_tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PKG: opcua-device-gateway
+          TAG: ${{ steps.versions.outputs.ci_tag }}
+        run: |
+          set +e
+          # ghcr.io packages live under either /users/<owner> or
+          # /orgs/<owner> depending on owner type. Probe and use whichever
+          # one returns the package.
+          TYPE=$(gh api "/users/$OWNER" --jq '.type' 2>/dev/null)
+          if [ "$TYPE" = "Organization" ]; then
+            BASE="/orgs/$OWNER/packages/container/$PKG/versions"
+          else
+            BASE="/users/$OWNER/packages/container/$PKG/versions"
+          fi
+
+          VID=$(gh api --paginate "$BASE" \
+            --jq ".[] | select(.metadata.container.tags[]? == \"$TAG\") | .id" \
+            | head -1)
+
+          if [ -z "$VID" ]; then
+            echo "No package version found for tag $TAG (already deleted?) — nothing to do."
+            exit 0
+          fi
+
+          echo "Deleting ghcr.io tag $TAG (version id $VID)..."
+          gh api -X DELETE "$BASE/$VID" && echo "Deleted." || \
+            echo "::warning::Failed to delete ghcr.io tag $TAG (version id $VID)"
 
   publish:
     name: Publish multi-arch image to ghcr.io

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -130,6 +130,7 @@ jobs:
         uses: ./.github/actions/integration-test
         with:
           image: ${{ steps.versions.outputs.ci_image }}
+          tedge_version: ${{ steps.versions.outputs.tedge_version }}
           c8y_host: ${{ secrets.C8Y_HOST }}
           c8y_user: ${{ secrets.C8Y_USER }}
           c8y_password: ${{ secrets.C8Y_PASSWORD }}

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -1,4 +1,9 @@
-name: Integration Test
+name: Integration Test (manual)
+
+# Standalone integration test against an already-published image (e.g. on
+# ghcr.io). The CI flow uses the composite action directly inside
+# `publish.yaml`; this workflow is only kept for manual dispatch when a
+# maintainer wants to re-validate a published image against C8Y.
 
 on:
   workflow_dispatch:
@@ -7,25 +12,9 @@ on:
         description: 'Full image ref to test (default: ghcr.io/<owner>/opcua-device-gateway:latest)'
         required: false
         type: string
-  workflow_call:
-    inputs:
-      image:
-        description: 'Full image ref to test'
-        required: true
-        type: string
-    secrets:
-      C8Y_HOST:
-        required: true
-      C8Y_USER:
-        required: true
-      C8Y_PASSWORD:
-        required: true
 
-# When called from another workflow, the caller already holds the shared
-# concurrency lock — use a per-run group to avoid deadlocking on ourselves.
-# When dispatched standalone, share the shared lock with publish.yaml.
 concurrency:
-  group: ${{ inputs.image && format('opcua-gateway-ci-inner-{0}', github.run_id) || 'opcua-gateway-ci' }}
+  group: opcua-gateway-ci
   cancel-in-progress: false
 
 jobs:
@@ -33,15 +22,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    env:
-      C8Y_HOST: ${{ secrets.C8Y_HOST }}
-      C8Y_USER: ${{ secrets.C8Y_USER }}
-      C8Y_PASSWORD: ${{ secrets.C8Y_PASSWORD }}
-      DEVICE_NAME: test-opcua-${{ github.run_id }}
-      C8Y_SETTINGS_SESSION_MODE: dev
-      # Required in non-TTY/CI envs: c8y v2 detects empty stdin as an empty
-      # pipeline and silently no-ops create commands without this flag.
-      C8Y_SETTINGS_DEFAULTS_ALLOWEMPTYPIPE: "true"
 
     steps:
       - name: Checkout
@@ -57,85 +37,10 @@ jobs:
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           echo "Testing image: $IMAGE"
 
-      - name: Install go-c8y-cli
-        uses: reubenmiller/setup-go-c8y-cli@v2
-
-      - name: Install c8y-tedge extension
-        run: c8y extension install thin-edge/c8y-tedge
-
-      - name: Download upstream compose and patch image
-        run: |
-          wget -q \
-            https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml \
-            -O patched-gateway-compose.yml
-
-          sed -i \
-            "s|image: ghcr.io/.*/opcua-device-gateway:.*|image: ${{ steps.img.outputs.image }}|" \
-            patched-gateway-compose.yml
-
-          echo "--- patched compose ---"
-          cat patched-gateway-compose.yml
-
-      - name: Download and patch startOPCDemoContainer.sh
-        run: |
-          UNIQUE_SW_NAME="opcua-device-gateway-ci-${{ github.run_id }}"
-          UNIQUE_OPCUA_SERVER_NAME="opcua-server-ci-${{ github.run_id }}"
-          echo "SW_NAME=$UNIQUE_SW_NAME" >> "$GITHUB_ENV"
-          echo "OPCUA_SERVER_NAME=$UNIQUE_OPCUA_SERVER_NAME" >> "$GITHUB_ENV"
-
-          wget -q \
-            https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/startOPCDemoContainer.sh \
-            -O startOPCDemoContainer.sh
-
-          # Replace the gateway compose URL with our locally patched file.
-          # Must happen BEFORE the renames below so the URL path still matches.
-          sed -i \
-            's|--url https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml|--file ./patched-gateway-compose.yml|' \
-            startOPCDemoContainer.sh
-
-          # Rename gateway software to a unique name to avoid cross-run conflicts.
-          sed -i "s|opcua-device-gateway|${UNIQUE_SW_NAME}|g" startOPCDemoContainer.sh
-          # Same for the opcua-server software (shared name in upstream script).
-          sed -i "s|opcua-server|${UNIQUE_OPCUA_SERVER_NAME}|g" startOPCDemoContainer.sh
-
-      - name: Run startOPCDemoContainer.sh
-        # The upstream script has a trailing buggy `sed` after Pump01 creation
-        # that exits non-zero even on success. Verify step is the source of truth.
-        continue-on-error: true
-        run: sh startOPCDemoContainer.sh "$DEVICE_NAME"
-
-      - name: Verify Pump01 device was created (test passed)
-        run: |
-          PUMP_ID=$(c8y inventory list \
-            --type c8y_OpcuaDevice \
-            --owner "device_$DEVICE_NAME" 2>/dev/null | jq -r '.id // empty')
-          if [ -z "$PUMP_ID" ]; then
-            echo "::error::Pump01 device not found — test FAILED"
-            exit 1
-          fi
-          echo "Test PASSED — Pump01 device found: $PUMP_ID"
-
-      - name: Cleanup — delete all test artifacts
-        if: always()
-        run: |
-          set +e
-          echo "--- Cleanup for run $DEVICE_NAME / $SW_NAME ---"
-
-          # Removes the tedge device, its child devices (Pump01), and the
-          # trusted device certificate in one shot.
-          c8y tedge demo delete "$DEVICE_NAME" || true
-
-          # Unique software entries (created this run only)
-          for NAME in "$SW_NAME" "$OPCUA_SERVER_NAME"; do
-            c8y software list --name "$NAME" --output json 2>/dev/null \
-              | jq -r '.id // empty' \
-              | while read -r ID; do
-                  [ -n "$ID" ] && c8y software delete --id "$ID" && \
-                    echo "Deleted software $NAME ($ID)"
-                done
-          done
-
-          # Stop the local docker compose stack
-          c8y tedge demo stop "$DEVICE_NAME" || true
-
-          echo "--- Cleanup done ---"
+      - name: Run integration test
+        uses: ./.github/actions/integration-test
+        with:
+          image: ${{ steps.img.outputs.image }}
+          c8y_host: ${{ secrets.C8Y_HOST }}
+          c8y_user: ${{ secrets.C8Y_USER }}
+          c8y_password: ${{ secrets.C8Y_PASSWORD }}

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -12,6 +12,10 @@ on:
         description: 'Full image ref to test (default: ghcr.io/<owner>/opcua-device-gateway:latest)'
         required: false
         type: string
+      tedge_version:
+        description: 'thin-edge.io version to install on the runner (leave empty for latest)'
+        required: false
+        type: string
 
 concurrency:
   group: opcua-gateway-ci
@@ -41,6 +45,7 @@ jobs:
         uses: ./.github/actions/integration-test
         with:
           image: ${{ steps.img.outputs.image }}
+          tedge_version: ${{ inputs.tedge_version }}
           c8y_host: ${{ secrets.C8Y_HOST }}
           c8y_user: ${{ secrets.C8Y_USER }}
           c8y_password: ${{ secrets.C8Y_PASSWORD }}

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -1,0 +1,141 @@
+name: Integration Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Full image ref to test (default: ghcr.io/<owner>/opcua-device-gateway:latest)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      image:
+        description: 'Full image ref to test'
+        required: true
+        type: string
+    secrets:
+      C8Y_HOST:
+        required: true
+      C8Y_USER:
+        required: true
+      C8Y_PASSWORD:
+        required: true
+
+# When called from another workflow, the caller already holds the shared
+# concurrency lock — use a per-run group to avoid deadlocking on ourselves.
+# When dispatched standalone, share the shared lock with publish.yaml.
+concurrency:
+  group: ${{ inputs.image && format('opcua-gateway-ci-inner-{0}', github.run_id) || 'opcua-gateway-ci' }}
+  cancel-in-progress: false
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      C8Y_HOST: ${{ secrets.C8Y_HOST }}
+      C8Y_USER: ${{ secrets.C8Y_USER }}
+      C8Y_PASSWORD: ${{ secrets.C8Y_PASSWORD }}
+      DEVICE_NAME: test-opcua-${{ github.run_id }}
+      C8Y_SETTINGS_SESSION_MODE: dev
+      # Required in non-TTY/CI envs: c8y v2 detects empty stdin as an empty
+      # pipeline and silently no-ops create commands without this flag.
+      C8Y_SETTINGS_DEFAULTS_ALLOWEMPTYPIPE: "true"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image
+        id: img
+        run: |
+          IMAGE="${{ inputs.image }}"
+          if [ -z "$IMAGE" ]; then
+            IMAGE="ghcr.io/${{ github.repository_owner }}/opcua-device-gateway:latest"
+          fi
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "Testing image: $IMAGE"
+
+      - name: Install go-c8y-cli
+        uses: reubenmiller/setup-go-c8y-cli@v2
+
+      - name: Install c8y-tedge extension
+        run: c8y extension install thin-edge/c8y-tedge
+
+      - name: Download upstream compose and patch image
+        run: |
+          wget -q \
+            https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml \
+            -O patched-gateway-compose.yml
+
+          sed -i \
+            "s|image: ghcr.io/.*/opcua-device-gateway:.*|image: ${{ steps.img.outputs.image }}|" \
+            patched-gateway-compose.yml
+
+          echo "--- patched compose ---"
+          cat patched-gateway-compose.yml
+
+      - name: Download and patch startOPCDemoContainer.sh
+        run: |
+          UNIQUE_SW_NAME="opcua-device-gateway-ci-${{ github.run_id }}"
+          UNIQUE_OPCUA_SERVER_NAME="opcua-server-ci-${{ github.run_id }}"
+          echo "SW_NAME=$UNIQUE_SW_NAME" >> "$GITHUB_ENV"
+          echo "OPCUA_SERVER_NAME=$UNIQUE_OPCUA_SERVER_NAME" >> "$GITHUB_ENV"
+
+          wget -q \
+            https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/startOPCDemoContainer.sh \
+            -O startOPCDemoContainer.sh
+
+          # Replace the gateway compose URL with our locally patched file.
+          # Must happen BEFORE the renames below so the URL path still matches.
+          sed -i \
+            's|--url https://raw.githubusercontent.com/thin-edge/opcua-solution-blueprint/refs/heads/main/software/docker-compose-opcua-device-gateway-demo-container.yml|--file ./patched-gateway-compose.yml|' \
+            startOPCDemoContainer.sh
+
+          # Rename gateway software to a unique name to avoid cross-run conflicts.
+          sed -i "s|opcua-device-gateway|${UNIQUE_SW_NAME}|g" startOPCDemoContainer.sh
+          # Same for the opcua-server software (shared name in upstream script).
+          sed -i "s|opcua-server|${UNIQUE_OPCUA_SERVER_NAME}|g" startOPCDemoContainer.sh
+
+      - name: Run startOPCDemoContainer.sh
+        # The upstream script has a trailing buggy `sed` after Pump01 creation
+        # that exits non-zero even on success. Verify step is the source of truth.
+        continue-on-error: true
+        run: sh startOPCDemoContainer.sh "$DEVICE_NAME"
+
+      - name: Verify Pump01 device was created (test passed)
+        run: |
+          PUMP_ID=$(c8y inventory list \
+            --type c8y_OpcuaDevice \
+            --owner "device_$DEVICE_NAME" 2>/dev/null | jq -r '.id // empty')
+          if [ -z "$PUMP_ID" ]; then
+            echo "::error::Pump01 device not found — test FAILED"
+            exit 1
+          fi
+          echo "Test PASSED — Pump01 device found: $PUMP_ID"
+
+      - name: Cleanup — delete all test artifacts
+        if: always()
+        run: |
+          set +e
+          echo "--- Cleanup for run $DEVICE_NAME / $SW_NAME ---"
+
+          # Removes the tedge device, its child devices (Pump01), and the
+          # trusted device certificate in one shot.
+          c8y tedge demo delete "$DEVICE_NAME" || true
+
+          # Unique software entries (created this run only)
+          for NAME in "$SW_NAME" "$OPCUA_SERVER_NAME"; do
+            c8y software list --name "$NAME" --output json 2>/dev/null \
+              | jq -r '.id // empty' \
+              | while read -r ID; do
+                  [ -n "$ID" ] && c8y software delete --id "$ID" && \
+                    echo "Deleted software $NAME ($ID)"
+                done
+          done
+
+          # Stop the local docker compose stack
+          c8y tedge demo stop "$DEVICE_NAME" || true
+
+          echo "--- Cleanup done ---"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+opcua-device-gateway.tar.gz
+*.tar.gz

--- a/containers/opcua-device-gateway/Dockerfile
+++ b/containers/opcua-device-gateway/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:12-slim
 ARG BUILDTIME
 ARG REVISION
 ARG VERSION=1023.1.1
+ARG TEDGE_VERSION
 
 LABEL org.opencontainers.image.title="thin-edge.io"
 LABEL org.opencontainers.image.created=$BUILDTIME
@@ -17,6 +18,7 @@ LABEL org.opencontainers.image.url="https://thin-edge.io"
 LABEL org.opencontainers.image.documentation="https://thin-edge.github.io/thin-edge.io/"
 LABEL org.opencontainers.image.base.name="debian:12-slim"
 LABEL com.cumulocity.image.opcua.version="$VERSION"
+LABEL com.thinedge.image.tedge.version="$TEDGE_VERSION"
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -31,7 +33,7 @@ RUN apt-get update \
 
 # Only install thin-edge.io to read the tedge config properties (see the entrypoint.sh)
 # TODO: In the future this coupling may be removed
-RUN wget -O - thin-edge.io/install.sh | sh -s
+RUN wget -O - thin-edge.io/install.sh | sh -s -- ${TEDGE_VERSION} --minimal
 
 WORKDIR /app
 

--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -68,9 +68,14 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
             echo "Fetching C8Y_BASEURL using: tedge config get c8y.url"
             C8Y_URL="$(tedge config get c8y.url 2>&1 ||:)"
             
-            # Check if the command returned an error message or empty value
+            # Check if the command returned an error message or empty value, fall back to c8y.http
             if [ -z "$C8Y_URL" ] || echo "$C8Y_URL" | grep -q "not set"; then
-                echo "ERROR: c8y.url is not configured in tedge config"
+                echo "c8y.url is not set, falling back to: tedge config get c8y.http"
+                C8Y_URL="$(tedge config get c8y.http 2>&1 ||:)"
+            fi
+
+            if [ -z "$C8Y_URL" ] || echo "$C8Y_URL" | grep -q "not set"; then
+                echo "ERROR: Neither c8y.url nor c8y.http is configured in tedge config"
                 exit 1
             fi
             

--- a/justfile
+++ b/justfile
@@ -1,12 +1,13 @@
 set dotenv-load
 
-export VERSION := env_var_or_default("VERSION", `date +'%Y%m%d.%H%M'`)
+# Combined version derived from .github/tracked-versions.json: "<opcua>-tedge<tedge>"
+export VERSION := env_var_or_default("VERSION", `jq -r '"\(.opcua_version)-tedge\(.tedge_version | gsub("[~+]"; "-"))"' .github/tracked-versions.json`)
 
 # Generate a version name (that can be used in follow up commands)
 generate_version:
     @echo "{{VERSION}}"
 
-# Trigger a release (by creating a tag)
+# Trigger a release (by creating a tag matching the image tag)
 release:
     git tag -a "{{VERSION}}" -m "{{VERSION}}"
     git push origin "{{VERSION}}"


### PR DESCRIPTION
## Summary

Adds an end-to-end CI pipeline for the OPC-UA device gateway container, plus automatic upstream version tracking.

### What runs and when

- **Daily cron + manual dispatch** (`.github/workflows/check-versions.yaml`):
  Compares the latest OPC-UA installer version on the public download page and the latest thin-edge `tedge-release` Cloudsmith package against `.github/tracked-versions.json`. If anything changed, it commits to the rolling branch `bot/bump-versions` and opens/updates a PR. Uses `WORKFLOW_PAT` so the PR triggers downstream `pull_request` workflows (the default `GITHUB_TOKEN` would not).

- **Build / integration test on every push and same-repo PR** (`.github/workflows/publish.yaml`, job `build-and-test`):
  1. Builds amd64 and pushes the freshly built image to ghcr.io under a throwaway tag `ci-<run_id>-<run_attempt>`.
  2. Runs the reusable composite action `.github/actions/integration-test` against a real Cumulocity tenant (`C8Y_HOST` / `C8Y_USER` / `C8Y_PASSWORD` secrets):
     - Downloads upstream `startOPCDemoContainer.sh` and `docker-compose-opcua-device-gateway-demo-container.yml`.
     - Patches the gateway compose `image:` to point at the throwaway ghcr.io tag.
     - Suffixes the two shared software names (`opcua-server`, `opcua-device-gateway`) with the run-scoped `DEVICE_NAME = test-opcua-<run_id>` so concurrent runs cannot collide on the c8y software repository.
     - Runs the upstream demo script verbatim against the real tenant.
     - Verifies the `Pump01` device of type `c8y_OpcuaDevice` was created.
     - Cleans up: deletes the demo device + its child devices + the trusted certificate, stops the local compose stack, and deletes the run-scoped software entries.
  3. Always-runs cleanup: deletes the throwaway ghcr.io `ci-…` tag.

- **Multi-arch publish on push to `main` and on dispatch only** (`publish.yaml`, job `publish`):
  Builds `linux/amd64,linux/arm64,linux/arm/v7` and pushes three tags to ghcr.io:
  - `<opcua>-tedge<tedge>` (rolling),
  - `<opcua>-tedge<tedge>-YYYYMMDD-<short-sha>` (immutable, lets you pin a known-good build even when the rolling tag rolls forward later in the same day),
  - `latest` (rolling).

- **Manual integration retest** (`.github/workflows/test-integration.yaml`):
  Standalone `workflow_dispatch` that runs the same composite action against an arbitrary image ref (e.g. `ghcr.io/.../opcua-device-gateway:latest`). Useful for re-validating an already-published image without rebuilding.

### Cross-repo / fork-PR safety

`build-and-test` is gated with `head.repo.full_name == github.repository`, so:
- Same-repo PRs (including the bot's `bot/bump-versions`) → full pipeline runs.
- External fork PRs → job is skipped (secrets not available, can't push to ghcr.io anyway).

### Why ghcr.io for the CI tag (not a local registry)

The first iteration used a local `registry:2` service container on the runner. That fails because podman runs **inside** the gateway container under test, where `localhost:5000` resolves to the container itself, not the runner host. Pushing the CI image to ghcr.io with a throwaway tag is the simplest path that keeps the unmodified gateway image as the test subject. The temp tag is deleted in an `always()` cleanup step.

### Other concerns from review

- `paths-ignore: ['**/*.md', 'LICENSE', 'docs/**']` on both `push` and `pull_request` triggers prevents doc-only commits from rebuilding/republishing the image.
- Per-PR concurrency cancels superseded runs; the rest of the cron / dispatch traffic is serialized via `opcua-gateway-ci`.
- Each `workflow_dispatch` input (`opcua_version`, `tedge_version`) falls back to `tracked-versions.json` independently.
- The cron uses `tedge-release` (not `tedge-main`) and does not strip metadata from the version string.

### Validation

The pipeline was tested end-to-end in `mstoffel-sag/opcua-device-gateway-container#3`. Latest run: build → push to ghcr.io ci tag → integration test against the live tenant → Pump01 verification → cleanup → ci tag deletion all green.

### New / changed files

- `.github/workflows/check-versions.yaml`
- `.github/workflows/publish.yaml`
- `.github/workflows/test-integration.yaml`
- `.github/actions/integration-test/action.yml`
- `.github/tracked-versions.json`
- `containers/opcua-device-gateway/Dockerfile` (accepts `TEDGE_VERSION` build-arg)
- `containers/opcua-device-gateway/entrypoint.sh` (c8y.http fallback)

### Required secrets

- `C8Y_HOST`, `C8Y_USER`, `C8Y_PASSWORD` — Cumulocity tenant for integration tests.
- `WORKFLOW_PAT` — repo-scoped PAT used by `check-versions.yaml` so its bot PRs trigger downstream workflows.
