### PR TITLE
fix(entrypoint): fall back to c8y.http when c8y.url is not configured

### DIFF
--- a/containers/opcua-device-gateway/entrypoint.sh
+++ b/containers/opcua-device-gateway/entrypoint.sh
@@ -68,9 +68,14 @@ if [ "$GATEWAY_THINEDGE_ENABLED" = true ]; then
             echo "Fetching C8Y_BASEURL using: tedge config get c8y.url"
             C8Y_URL="$(tedge config get c8y.url 2>&1 ||:)"
             
-            # Check if the command returned an error message or empty value
+            # Check if the command returned an error message or empty value, fall back to c8y.http
             if [ -z "$C8Y_URL" ] || echo "$C8Y_URL" | grep -q "not set"; then
-                echo "ERROR: c8y.url is not configured in tedge config"
+                echo "c8y.url is not set, falling back to: tedge config get c8y.http"
+                C8Y_URL="$(tedge config get c8y.http 2>&1 ||:)"
+            fi
+
+            if [ -z "$C8Y_URL" ] || echo "$C8Y_URL" | grep -q "not set"; then
+                echo "ERROR: Neither c8y.url nor c8y.http is configured in tedge config"
                 exit 1
             fi
             


### PR DESCRIPTION
## Problem

New thinEdge demo container detects a custom domain and filles `c8y.http` rather than `c8y.url`. When `c8y.url` returns empty or \`not set\`, the gateway entrypoint immediately exits with an error, preventing the gateway from starting.

## Fix

Try `c8y.url` first (existing behaviour). If that is empty or \`not set\`, fall back to `c8y.http`. Only exit with an error if **both** are unset.

```diff
-            if [ -z "$C8Y_URL" ] || echo "$C8Y_URL" | grep -q "not set"; then
-                echo "ERROR: c8y.url is not configured in tedge config"
+            if [ -z "$C8Y_URL" ] || echo "$C8Y_URL" | grep -q "not set"; then
+                echo "c8y.url is not set, falling back to: tedge config get c8y.http"
+                C8Y_URL="$(tedge config get c8y.http 2>&1 ||:)"
+            fi
+
+            if [ -z "$C8Y_URL" ] || echo "$C8Y_URL" | grep -q "not set"; then
+                echo "ERROR: Neither c8y.url nor c8y.http is configured in tedge config"
                 exit 1
             fi
```

## Impact

No change in behaviour when `c8y.url` is set. When only `c8y.http` is set (thin-edge ≥ 1.x with the new config key), the gateway starts correctly.